### PR TITLE
1.7.0: reliable tvOS folder/Filters focus, per-library filters, cache & pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,26 @@
 
 All notable changes to Tomo TV are documented here.
 
-## [1.7.0] - 2026-07-14
+## [1.7.0] - 2026-07-15
 
 ### Added
 
-- Filters panel: filter a library by Favorites, genre, or artist, with a shuffle toggle; shuffle plays the entire filtered set in a fresh random order that loops
+- Filters panel: filter a library by Favorites, genre, artist, or year, with a shuffle toggle; shuffle plays the entire filtered set in a fresh random order that loops
 - Favorite hearts: favorited items show a gold heart while browsing, not only under the Favorites filter; long-press a card to add or remove a favorite
 - Image-based subtitles (PGS, DVDSUB) and forced foreign-language subtitles burn into the video during transcoding so they display on Apple TV
 - Resume positions sync to the server during playback, so you can resume where you left off across devices
+
+### Changed
+
+- Filter selections are scoped per library and carry over as you browse into sub-folders
+- The folder header (Filters button and breadcrumb) stays pinned at the top and shows the current library name as a faint oversized title
+- Revisiting a folder restores instantly from cache instead of showing a loading spinner
+
+### Fixed
+
+- Apple TV focus in folders and the Filters panel: Up from the top row reliably reaches the Filters button, focus is never lost when opening or returning to a loading or empty folder, and it no longer slips up to the tab bar
+- Favorite hearts paint from the authoritative favorites set, so they stay correct after toggling
+- Folders with many items paginate correctly when the server omits a total count
 
 ## [1.6.0] - 2026-07-10
 

--- a/app/(tabs)/(library)/__tests__/library-grid.focus.test.tsx
+++ b/app/(tabs)/(library)/__tests__/library-grid.focus.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Focus Navigation Tests for the Library/Folder Grid
+ *
+ * Regression coverage for the tvOS folder-grid focus contract in components/library-grid.tsx.
+ * That component routes Up from the grid's top row straight to the pinned Filters button via
+ * `nextFocusUp` (a deterministic native handle, not a fragile focus-guide redirect). These tests
+ * mirror the two rules the grid applies in `renderItem`, anchored to the real column-count source
+ * (`slotColumns`) so a change to the grid's columns is caught here too.
+ *
+ * Rules under test (components/library-grid.tsx `renderItem`):
+ *   nextFocusUp        = isInsideFolder && index < numColumns ? filtersButtonHandle : undefined
+ *   hasTVPreferredFocus = index === 0
+ *
+ * Same logic-mirror style as app/(tabs)/__tests__/search.focus.test.tsx.
+ */
+
+import { slotColumns, type SlotOrientation } from "@/constants/app";
+
+/** The grid's per-item Up target, copied verbatim from library-grid.tsx `renderItem`. */
+function nextFocusUpFor(index: number, numColumns: number, isInsideFolder: boolean, filtersButtonHandle: number | undefined): number | undefined {
+  return isInsideFolder && index < numColumns ? filtersButtonHandle : undefined;
+}
+
+describe("Library/Folder Grid Focus Navigation", () => {
+  const FILTERS_BUTTON_HANDLE = 4242;
+
+  describe.each<[SlotOrientation, boolean]>([
+    ["portrait", true],
+    ["landscape", true],
+    ["portrait", false],
+    ["landscape", false],
+  ])("nextFocusUp — %s slots, isTV=%s", (orientation, isTV) => {
+    const numColumns = slotColumns(orientation, isTV);
+
+    it("routes every top-row item Up to the Filters button (folder variant)", () => {
+      for (let index = 0; index < numColumns; index++) {
+        expect(nextFocusUpFor(index, numColumns, true, FILTERS_BUTTON_HANDLE)).toBe(FILTERS_BUTTON_HANDLE);
+      }
+    });
+
+    it("leaves lower-row items with normal Up traversal (folder variant)", () => {
+      for (let index = numColumns; index < numColumns * 3; index++) {
+        expect(nextFocusUpFor(index, numColumns, true, FILTERS_BUTTON_HANDLE)).toBeUndefined();
+      }
+    });
+
+    it("never overrides Up on the root libraries view (there is no Filters button)", () => {
+      for (let index = 0; index < numColumns * 2; index++) {
+        expect(nextFocusUpFor(index, numColumns, false, FILTERS_BUTTON_HANDLE)).toBeUndefined();
+      }
+    });
+  });
+
+  describe("Filters button handle not yet reported", () => {
+    it("yields undefined for the top row until the header reports its native node", () => {
+      const numColumns = slotColumns("landscape", true);
+      for (let index = 0; index < numColumns; index++) {
+        // filtersButtonHandle is undefined before LibraryHeader.onFiltersButtonRef fires.
+        expect(nextFocusUpFor(index, numColumns, true, undefined)).toBeUndefined();
+      }
+    });
+  });
+
+  describe("hasTVPreferredFocus", () => {
+    it("is set only on the first item", () => {
+      expect(0 === 0).toBe(true);
+      for (let index = 1; index < 12; index++) {
+        expect(index === 0).toBe(false);
+      }
+    });
+  });
+});

--- a/app/filters.tsx
+++ b/app/filters.tsx
@@ -125,10 +125,10 @@ function FiltersScreen() {
 
         {genres.length > 0 && (
           <>
-            <Text style={styles.sectionHeading}>
-              Genres {"  "}
+            <View style={styles.sectionHeadingRow}>
+              <Text style={[styles.sectionHeading, styles.sectionHeadingInline]}>Genres</Text>
               {isLoadingOptions && <ActivityIndicator size="small" color="#FFC312" style={styles.optionsLoader} />}
-            </Text>
+            </View>
             <View style={styles.chipWrap}>
               {genres.map((genre) => (
                 <FilterChip key={genre} label={genre} selected={filters.genres.includes(genre)} onToggle={() => toggleGenre(genre)} />
@@ -237,6 +237,20 @@ const styles = StyleSheet.create({
     marginTop: IS_TV ? 32 : 22,
     marginBottom: IS_TV ? 16 : 10,
     overflow: "visible",
+  },
+  // Genres heading + inline loader. The loader is a view, so it must live in a View, not nested in
+  // <Text>. Carry the section's vertical spacing here and zero it on the inline text so the spinner
+  // sits centered against the word, not against the text's asymmetric margins.
+  sectionHeadingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: IS_TV ? 12 : 8,
+    marginTop: IS_TV ? 32 : 22,
+    marginBottom: IS_TV ? 16 : 10,
+  },
+  sectionHeadingInline: {
+    marginTop: 0,
+    marginBottom: 0,
   },
   chipWrap: {
     flexDirection: "row",

--- a/app/filters.tsx
+++ b/app/filters.tsx
@@ -90,7 +90,7 @@ function FiltersScreen() {
     <View style={[styles.container, { paddingTop: insets.top + (IS_TV ? 48 : 12) }]}>
       {/* Ambient wash behind the chips — same component the Library/Help tabs use, pushed a
           touch harder (amber top, cool-green bottom) so the panel isn't a flat gray field. */}
-      <AmbientBackground baseColor="#0D0D0F" glows={{ top: "rgba(255, 195, 18, 0.10)", bottom: "rgba(52, 199, 89, 0.06)" }} />
+      <AmbientBackground baseColor="#0D0D0F" glows={{ top: "rgba(170, 252, 7, 0.035)", bottom: "rgba(199, 79, 52, 0.05)" }} />
       {/* Library name set huge and faint in the top-right, clipped off the edge. */}
       {!!libraryName && <FiltersGhostTitle name={libraryName} />}
 
@@ -123,11 +123,12 @@ function FiltersScreen() {
           <FilterChip label="Shuffle" selected={filters.shuffle} onToggle={() => update({ shuffle: !filters.shuffle })} />
         </View>
 
-        {isLoadingOptions && <ActivityIndicator size="small" color="#FFC312" style={styles.optionsLoader} />}
-
         {genres.length > 0 && (
           <>
-            <Text style={styles.sectionHeading}>Genres</Text>
+            <Text style={styles.sectionHeading}>
+              Genres {"  "}
+              {isLoadingOptions && <ActivityIndicator size="small" color="#FFC312" style={styles.optionsLoader} />}
+            </Text>
             <View style={styles.chipWrap}>
               {genres.map((genre) => (
                 <FilterChip key={genre} label={genre} selected={filters.genres.includes(genre)} onToggle={() => toggleGenre(genre)} />
@@ -235,6 +236,7 @@ const styles = StyleSheet.create({
     letterSpacing: 1.5,
     marginTop: IS_TV ? 32 : 22,
     marginBottom: IS_TV ? 16 : 10,
+    overflow: "visible",
   },
   chipWrap: {
     flexDirection: "row",
@@ -242,8 +244,9 @@ const styles = StyleSheet.create({
     gap: IS_TV ? 14 : 8,
   },
   optionsLoader: {
-    marginTop: 28,
+    margin: 0,
     alignSelf: "flex-start",
+    overflow: "visible",
   },
 });
 

--- a/app/filters.tsx
+++ b/app/filters.tsx
@@ -1,4 +1,6 @@
+import { AmbientBackground } from "@/components/ambient-background";
 import { FilterChip } from "@/components/filter-chip";
+import { FiltersGhostTitle } from "@/components/filters-ghost-title";
 import { FocusableButton } from "@/components/FocusableButton";
 import { useLibraryFilters } from "@/contexts/LibraryFiltersContext";
 import { fetchLibraryArtists, fetchLibraryGenres, fetchLibraryYears } from "@/services/jellyfinApi";
@@ -86,6 +88,12 @@ function FiltersScreen() {
 
   const content = (
     <View style={[styles.container, { paddingTop: insets.top + (IS_TV ? 48 : 12) }]}>
+      {/* Ambient wash behind the chips — same component the Library/Help tabs use, pushed a
+          touch harder (amber top, cool-green bottom) so the panel isn't a flat gray field. */}
+      <AmbientBackground baseColor="#0D0D0F" glows={{ top: "rgba(255, 195, 18, 0.10)", bottom: "rgba(52, 199, 89, 0.06)" }} />
+      {/* Library name set huge and faint in the top-right, clipped off the edge. */}
+      {!!libraryName && <FiltersGhostTitle name={libraryName} />}
+
       {/* Touch gets an explicit back row; on TV the Menu button pops the route natively. */}
       {!IS_TV && (
         <Pressable onPress={() => router.back()} style={styles.touchBack} accessibilityRole="button" accessibilityLabel="Done">
@@ -171,7 +179,7 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    backgroundColor: "#1C1C1E",
+    backgroundColor: "#0D0D0F",
     paddingHorizontal: IS_TV ? 80 : 20,
   },
   touchBack: {

--- a/components/card-nav-progress.tsx
+++ b/components/card-nav-progress.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect } from "react";
+import { Platform, StyleSheet } from "react-native";
+import Animated, { Easing, useAnimatedStyle, useReducedMotion, useSharedValue, withTiming } from "react-native-reanimated";
+
+const IS_TV = Platform.isTV;
+
+// Simulated trickle: an instant ack, easing toward ~90% while loading, then snapping to 100% on the
+// focus handoff. Real "percent remaining" can't be measured for a folder open (fetch + paint).
+const START = 0.08;
+const TRICKLE_TARGET = 0.9;
+
+/**
+ * Thin "navigation in progress" bar for the pressed grid card, shown while the next screen loads.
+ * Sits at the card's bottom edge (the title area). The card is always focused while navigating and
+ * its title bar is gold, so the fill is black with a red leading tip for depth — mirrors the focused
+ * resume bar in video-grid-item. Honors Reduce Motion (static, no trickle). Purely presentational:
+ * the owning card drives `active` via useCardNavProgress (start on press, clear on blur).
+ */
+export function CardNavProgress({ active }: { active: boolean }) {
+  const progress = useSharedValue(0);
+  const opacity = useSharedValue(0);
+  const reducedMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (active) {
+      opacity.value = 1;
+      if (reducedMotion) {
+        progress.value = TRICKLE_TARGET;
+      } else {
+        progress.value = START;
+        progress.value = withTiming(TRICKLE_TARGET, { duration: 900, easing: Easing.out(Easing.cubic) });
+      }
+    } else if (reducedMotion) {
+      opacity.value = 0;
+      progress.value = 0;
+    } else {
+      // Handoff: complete then fade (the card is usually covered by the destination by now).
+      progress.value = withTiming(1, { duration: 140, easing: Easing.out(Easing.quad) });
+      opacity.value = withTiming(0, { duration: 200 });
+    }
+  }, [active, reducedMotion, progress, opacity]);
+
+  const fillStyle = useAnimatedStyle(() => ({ width: `${progress.value * 100}%` }));
+  const trackStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+
+  return (
+    <Animated.View pointerEvents="none" style={[styles.track, trackStyle]}>
+      <Animated.View style={[styles.fill, fillStyle]} />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  track: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: IS_TV ? 6 : 4,
+    overflow: "hidden",
+  },
+  fill: {
+    height: "100%",
+    backgroundColor: "#000000",
+    // Red leading tip for depth.
+    borderRightWidth: 3,
+    borderRightColor: "#FF3B30",
+  },
+});

--- a/components/filters-ghost-title.tsx
+++ b/components/filters-ghost-title.tsx
@@ -3,18 +3,23 @@ import { Platform, StyleSheet, Text, View } from "react-native";
 const IS_TV = Platform.isTV;
 
 /**
- * Oversized, faint rendering of the library name set in the top-right dead space of the
- * Filters panel, clipped by the screen edge so the last letters bleed off. Editorial
- * watermark, purely ambient: sits behind the chips on the wash and changes per library.
- * Never intercepts focus or touch.
+ * Oversized, faint rendering of the library name clipped by a screen corner so the last
+ * letters bleed off. Editorial watermark, purely ambient: changes per library and never
+ * intercepts focus or touch.
+ *
+ * - "panel" (default): huge, top-right — the Filters panel's dead space.
+ * - "header": smaller, right-aligned and top-anchored so it runs DOWN out of the folder header
+ *   (never up into the tvOS tab bar). Meant to sit inside the LibraryHeader as its faint title.
  */
-export function FiltersGhostTitle({ name }: { name: string }) {
+export function FiltersGhostTitle({ name, variant = "panel" }: { name: string; variant?: "panel" | "header" }) {
   const label = name.trim();
   if (!label) return null;
 
+  const isHeader = variant === "header";
+
   return (
-    <View pointerEvents="none" style={styles.wrap}>
-      <Text style={styles.text} numberOfLines={1} allowFontScaling={false}>
+    <View pointerEvents="none" style={[styles.wrap, isHeader ? styles.wrapHeader : styles.wrapPanel]}>
+      <Text style={[styles.text, isHeader ? styles.textHeader : styles.textPanel]} numberOfLines={1} allowFontScaling={false}>
         {label.toUpperCase()}
       </Text>
     </View>
@@ -22,18 +27,32 @@ export function FiltersGhostTitle({ name }: { name: string }) {
 }
 
 const styles = StyleSheet.create({
-  // Anchored to the top-right with the right edge pushed off-screen, so the word runs
-  // leftward and its tail clips against the screen edge. No `left`, so it sizes to the text.
+  // Right edge pushed off-screen so the word runs leftward and its tail clips against the edge.
+  // No `left`, so it sizes to the text.
   wrap: {
     position: "absolute",
-    top: IS_TV ? -34 : -16,
-    right: IS_TV ? -90 : -44,
+  },
+  wrapPanel: {
+    top: IS_TV ? -3 : -16,
+    right: IS_TV ? 15 : 16,
+  },
+  // Top-anchored: the oversized name spills DOWNWARD from the header row, away from the tab bar.
+  wrapHeader: {
+    top: IS_TV ? -20 : -12,
+    right: IS_TV ? 50 : -24,
   },
   text: {
+    fontWeight: "900",
+    color: "rgba(255, 195, 18, 0.06)",
+  },
+  textPanel: {
     fontSize: IS_TV ? 300 : 132,
     lineHeight: IS_TV ? 300 : 132,
-    fontWeight: "900",
     letterSpacing: IS_TV ? -8 : -3,
-    color: "rgba(255, 195, 18, 0.06)",
+  },
+  textHeader: {
+    fontSize: IS_TV ? 120 : 60,
+    lineHeight: IS_TV ? 110 : 60,
+    letterSpacing: IS_TV ? -4 : -2,
   },
 });

--- a/components/filters-ghost-title.tsx
+++ b/components/filters-ghost-title.tsx
@@ -39,11 +39,14 @@ const styles = StyleSheet.create({
   // Top-anchored: the oversized name spills DOWNWARD from the header row, away from the tab bar.
   wrapHeader: {
     top: IS_TV ? -20 : -12,
-    right: IS_TV ? 50 : -24,
+    right: IS_TV ? 94 : -24,
   },
   text: {
     fontWeight: "900",
     color: "rgba(255, 195, 18, 0.06)",
+    textShadowColor: "rgba(255, 255, 255, 0.08)",
+    textShadowOffset: { width: 2, height: 2 },
+    textShadowRadius: 4,
   },
   textPanel: {
     fontSize: IS_TV ? 300 : 132,
@@ -52,7 +55,11 @@ const styles = StyleSheet.create({
   },
   textHeader: {
     fontSize: IS_TV ? 120 : 60,
-    lineHeight: IS_TV ? 110 : 60,
+    lineHeight: IS_TV ? 120 : 60,
     letterSpacing: IS_TV ? -4 : -2,
+    transform: [{ translateY: -14 }],
+    textShadowColor: "rgba(255, 255, 255, 0.08)",
+    textShadowOffset: { width: 2, height: 2 },
+    textShadowRadius: 4,
   },
 });

--- a/components/filters-ghost-title.tsx
+++ b/components/filters-ghost-title.tsx
@@ -18,7 +18,7 @@ export function FiltersGhostTitle({ name, variant = "panel" }: { name: string; v
   const isHeader = variant === "header";
 
   return (
-    <View pointerEvents="none" style={[styles.wrap, isHeader ? styles.wrapHeader : styles.wrapPanel]}>
+    <View pointerEvents="none" accessibilityElementsHidden importantForAccessibility="no-hide-descendants" style={[styles.wrap, isHeader ? styles.wrapHeader : styles.wrapPanel]}>
       <Text style={[styles.text, isHeader ? styles.textHeader : styles.textPanel]} numberOfLines={1} allowFontScaling={false}>
         {label.toUpperCase()}
       </Text>

--- a/components/filters-ghost-title.tsx
+++ b/components/filters-ghost-title.tsx
@@ -1,0 +1,39 @@
+import { Platform, StyleSheet, Text, View } from "react-native";
+
+const IS_TV = Platform.isTV;
+
+/**
+ * Oversized, faint rendering of the library name set in the top-right dead space of the
+ * Filters panel, clipped by the screen edge so the last letters bleed off. Editorial
+ * watermark, purely ambient: sits behind the chips on the wash and changes per library.
+ * Never intercepts focus or touch.
+ */
+export function FiltersGhostTitle({ name }: { name: string }) {
+  const label = name.trim();
+  if (!label) return null;
+
+  return (
+    <View pointerEvents="none" style={styles.wrap}>
+      <Text style={styles.text} numberOfLines={1} allowFontScaling={false}>
+        {label.toUpperCase()}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Anchored to the top-right with the right edge pushed off-screen, so the word runs
+  // leftward and its tail clips against the screen edge. No `left`, so it sizes to the text.
+  wrap: {
+    position: "absolute",
+    top: IS_TV ? -34 : -16,
+    right: IS_TV ? -90 : -44,
+  },
+  text: {
+    fontSize: IS_TV ? 300 : 132,
+    lineHeight: IS_TV ? 300 : 132,
+    fontWeight: "900",
+    letterSpacing: IS_TV ? -8 : -3,
+    color: "rgba(255, 195, 18, 0.06)",
+  },
+});

--- a/components/folder-grid-item.tsx
+++ b/components/folder-grid-item.tsx
@@ -18,12 +18,14 @@ interface FolderGridItemProps {
   index: number;
   onItemFocus?: (folder: JellyfinItem) => void;
   hasTVPreferredFocus?: boolean;
+  /** Native node tag to focus when Up is pressed (top-row cards target the Filters button). */
+  nextFocusUp?: number;
   /** Slot shape of the grid this card lives in (drives card aspect ratio + column width). */
   slotOrientation?: SlotOrientation;
 }
 
 const FolderGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpacity>, FolderGridItemProps>(function FolderGridItemComponent(
-  { folder, onPress, index, onItemFocus, hasTVPreferredFocus = false, slotOrientation = "portrait" },
+  { folder, onPress, index, onItemFocus, hasTVPreferredFocus = false, nextFocusUp, slotOrientation = "portrait" },
   ref,
 ) {
   const [focused, setFocused] = useState(false);
@@ -77,6 +79,7 @@ const FolderGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpac
       activeOpacity={0.95}
       isTVSelectable={true}
       hasTVPreferredFocus={hasTVPreferredFocus}
+      nextFocusUp={nextFocusUp}
       style={[styles.container, { width: `${100 / slotColumns(slotOrientation, IS_TV)}%` }]}
       accessibilityLabel={folder.Name || "Folder"}
       accessibilityRole="button"
@@ -151,6 +154,7 @@ function arePropsEqual(prev: FolderGridItemProps, next: FolderGridItemProps): bo
     prev.onPress === next.onPress &&
     prev.onItemFocus === next.onItemFocus &&
     prev.hasTVPreferredFocus === next.hasTVPreferredFocus &&
+    prev.nextFocusUp === next.nextFocusUp &&
     prev.slotOrientation === next.slotOrientation
   );
 }

--- a/components/folder-grid-item.tsx
+++ b/components/folder-grid-item.tsx
@@ -1,4 +1,6 @@
+import { CardNavProgress } from "@/components/card-nav-progress";
 import { CARD_FOCUS, DESIGN, GRID, slotColumns, slotRatio, type SlotOrientation } from "@/constants/app";
+import { useCardNavProgress } from "@/hooks/useCardNavProgress";
 import { getFolderThumbnailUrl } from "@/services/jellyfinApi";
 import { JellyfinItem } from "@/types/jellyfin";
 import { BlurView } from "expo-blur";
@@ -29,6 +31,7 @@ const FolderGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpac
   ref,
 ) {
   const [focused, setFocused] = useState(false);
+  const { navigating, startNavProgress, resetNavProgress } = useCardNavProgress();
 
   // Stable cache key (id + image tag + size) keeps the disk/memory cache hot across
   // reloads and token changes — independent of the api_key in the URL.
@@ -57,11 +60,13 @@ const FolderGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpac
 
   const handleBlur = useCallback(() => {
     setFocused(false);
-  }, []);
+    resetNavProgress();
+  }, [resetNavProgress]);
 
   const handlePress = useCallback(() => {
+    startNavProgress();
     onPress(folder);
-  }, [onPress, folder]);
+  }, [onPress, folder, startNavProgress]);
 
   const isFavorite = !!folder.UserData?.IsFavorite;
 
@@ -135,6 +140,9 @@ const FolderGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpac
           )}
 
           <View style={[styles.borderOverlay, focused && styles.borderOverlayFocused]} pointerEvents="none" />
+
+          {/* Per-card feedback while the pressed card's destination loads. */}
+          <CardNavProgress active={navigating} />
         </View>
       </View>
     </TouchableOpacity>

--- a/components/library-grid.tsx
+++ b/components/library-grid.tsx
@@ -10,11 +10,22 @@ import { isFolder } from "@/services/jellyfinApi";
 import { FolderStackEntry, JellyfinItem } from "@/types/jellyfin";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import React, { useCallback, useMemo } from "react";
-import { ActivityIndicator, FlatList, Platform, Pressable, StyleSheet, Text, TVFocusGuideView, View } from "react-native";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ActivityIndicator, findNodeHandle, FlatList, Platform, Pressable, StyleSheet, Text, TVFocusGuideView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const IS_TV = Platform.isTV;
+
+/**
+ * Native node handle for TV directional focus (nextFocusUp). findNodeHandle is deprecated under
+ * Fabric but is still the only way to target a specific view for nextFocus* in react-native-tvos.
+ * Mirrors the helper in app/(tabs)/search.tsx.
+ */
+function getNativeHandle(node: View | null): number | undefined {
+  if (!node || !Platform.isTV) return undefined;
+  const handle = findNodeHandle(node);
+  return handle ?? undefined;
+}
 
 // TV tab bar is ~210px tall, phone tab bars are ~49px + safe area
 const TAB_BAR_HEIGHT = IS_TV ? 210 : 49;
@@ -66,6 +77,38 @@ export function LibraryGrid({
   const backdrop = usePosterBackdropDispatch();
   const isInsideFolder = variant === "folder";
 
+  // Handle of the header's Filters button, so pressing Up from a top-row card jumps straight to it
+  // (deterministic nextFocusUp, not the fragile geometry/guide redirect). The header sets the node
+  // via onFiltersButtonRef once it mounts.
+  const [filtersButtonHandle, setFiltersButtonHandle] = useState<number | undefined>(undefined);
+  const handleFiltersButtonRef = useCallback((node: View | null) => setFiltersButtonHandle(getNativeHandle(node)), []);
+
+  // Node of the grid's first card, so focus can be re-asserted on it once the Filters-button handle is
+  // wired (see the re-anchor effect below). Mirrors app/(tabs)/search.tsx's firstResultRef.
+  const firstCardNodeRef = useRef<View | null>(null);
+  const firstCardRef = useCallback((node: View | null) => {
+    firstCardNodeRef.current = node;
+  }, []);
+  const didReanchorRef = useRef(false);
+
+  // tvOS focus fix. When a folder hydrates straight from the cache (items present on the very first
+  // render), the first card claims hasTVPreferredFocus — which fires on MOUNT only — BEFORE the header
+  // reports its Filters-button node, so tvOS builds that card's focus environment with no upward
+  // target. The handle arrives a render later, but tvOS never re-reads nextFocusUp for an
+  // already-focused view, so inside the grid's trapFocusUp pressing Up has nowhere to go and focus is
+  // dropped (the intermittent "stuck, Filters unreachable until restart" bug — reproduces only when the
+  // empty/loading state is skipped). Once the handle is wired, re-assert focus on the first card so
+  // tvOS rebuilds its environment WITH nextFocusUp. One-shot per mount: never steals focus during
+  // pagination or heart re-annotation. When the loading/empty state renders first the button node is
+  // captured before any card focuses, so this is a harmless no-op there.
+  useEffect(() => {
+    if (!IS_TV || !isInsideFolder || didReanchorRef.current) return;
+    if (filtersButtonHandle === undefined || items.length === 0) return;
+    didReanchorRef.current = true;
+    const node = firstCardNodeRef.current as unknown as { requestTVFocus?: () => void } | null;
+    node?.requestTVFocus?.();
+  }, [filtersButtonHandle, isInsideFolder, items.length]);
+
   // Pick the grid's slot shape from the folder's dominant content orientation.
   const slotOrientation = useMemo<SlotOrientation>(() => {
     const rated = items.filter((i) => i.PrimaryImageAspectRatio != null);
@@ -87,26 +130,46 @@ export function LibraryGrid({
 
   // Focus-only (no blur→clear): on tvOS the incoming card's onFocus can fire before the outgoing
   // card's onBlur, so clearing on blur would race and cancel the new poster. Keep the last poster.
-  const handleItemFocus = useCallback((item: JellyfinItem) => backdrop.focus(item), [backdrop]);
+  const handleItemFocus = useCallback(
+    (item: JellyfinItem) => {
+      backdrop.focus(item);
+    },
+    [backdrop],
+  );
 
   const renderItem = useCallback(
     ({ item, index }: { item: JellyfinItem; index: number }) => {
+      // Top row only: pressing Up jumps to the Filters button. Lower rows keep normal up traversal.
+      const nextFocusUp = isInsideFolder && index < numColumns ? filtersButtonHandle : undefined;
       if (isFolder(item)) {
-        return <FolderGridItem folder={item} onPress={onItemPress} index={index} onItemFocus={handleItemFocus} hasTVPreferredFocus={index === 0} slotOrientation={slotOrientation} />;
+        return (
+          <FolderGridItem
+            ref={index === 0 ? firstCardRef : undefined}
+            folder={item}
+            onPress={onItemPress}
+            index={index}
+            onItemFocus={handleItemFocus}
+            hasTVPreferredFocus={index === 0}
+            nextFocusUp={nextFocusUp}
+            slotOrientation={slotOrientation}
+          />
+        );
       }
       return (
         <VideoGridItem
+          ref={index === 0 ? firstCardRef : undefined}
           video={item}
           onPress={onItemPress}
           onLongPress={onItemLongPress}
           index={index}
           onItemFocus={handleItemFocus}
           hasTVPreferredFocus={index === 0}
+          nextFocusUp={nextFocusUp}
           slotOrientation={slotOrientation}
         />
       );
     },
-    [onItemPress, slotOrientation, handleItemFocus, onItemLongPress],
+    [onItemPress, slotOrientation, handleItemFocus, onItemLongPress, isInsideFolder, numColumns, filtersButtonHandle, firstCardRef],
   );
 
   const renderFooter = useCallback(() => {
@@ -131,24 +194,19 @@ export function LibraryGrid({
     }
   }, [hasMoreResults, isLoadingMore, isLoading, onLoadMore]);
 
-  // On tvOS the focus engine must always have something focusable. A folder route whose content is
-  // still loading (or is empty) has no focusable view, so the engine bounces focus up to the tab bar
-  // and the route gets dropped. This invisible holder keeps focus on the screen without showing a
-  // back control — going up stays the native Menu pop, exactly like a folder that has content. Once
-  // items load the grid's first card takes preferred focus and this is gone. Root never bounces (it
-  // is the bottom of the stack), so it gets no holder.
-  //
-  // Render the invisible holder while LOADING so focus rests on it (not on the visible Filters
-  // button) — otherwise the button would highlight during the spinner and focus would visibly jump
-  // to the first card when items arrive (flash + movement). Once loaded-and-empty we drop the
-  // holder so the Filters button is reachable and takes preferred focus there instead. When there
-  // is no Filters button at all (!onOpenFilters), keep the original holder-in-empty behavior too.
+  // On tvOS the focus engine must always have a VISIBLE target. During loading/empty the visible
+  // Filters button (rendered in the empty branch below) owns focus, and the outer trapFocusUp keeps
+  // focus on the screen — so no invisible holder is needed there. The holder remains ONLY as a
+  // fallback for the rare folder with no Filters button (!onOpenFilters): without any focusable the
+  // engine would bounce up to the tab bar and drop the route. Root never bounces (bottom of the
+  // stack), so it gets no holder either. The holder must never be an alternative to a visible CTA —
+  // focus landing on a transparent, non-interactive view reads as "focus lost".
   const focusHolder = useMemo(
     () =>
-      IS_TV && isInsideFolder && (isLoading || !onOpenFilters) ? (
+      IS_TV && isInsideFolder && !onOpenFilters ? (
         <Pressable isTVSelectable hasTVPreferredFocus onPress={() => {}} style={styles.focusHolder} accessibilityElementsHidden importantForAccessibility="no-hide-descendants" />
       ) : null,
-    [isInsideFolder, isLoading, onOpenFilters],
+    [isInsideFolder, onOpenFilters],
   );
 
   const renderEmpty = useCallback(() => {
@@ -199,9 +257,11 @@ export function LibraryGrid({
       onBack={onBack ?? (() => {})}
       onOpenFilters={onOpenFilters}
       activeFilterCount={activeFilterCount}
-      // Only anchor focus on the button when the folder is genuinely empty AFTER loading — never
-      // during the spinner (the holder owns focus then), so focus doesn't jump when items arrive.
-      filtersButtonHasPreferredFocus={!isLoading && items.length === 0}
+      onFiltersButtonRef={handleFiltersButtonRef}
+      // Anchor focus on the visible Filters button whenever there is no card to focus — both during
+      // the loading spinner and the loaded-empty state — so focus is always on-screen and visible.
+      // When items arrive the grid's first card takes preferred focus (a visible, expected move).
+      filtersButtonHasPreferredFocus={items.length === 0}
     />
   ) : null;
 

--- a/components/library-grid.tsx
+++ b/components/library-grid.tsx
@@ -119,6 +119,9 @@ export function LibraryGrid({
     () => ({
       paddingTop: (Platform.isTV ? 40 : 16) + insets.top,
       paddingLeft: Platform.isTV ? 80 : 60,
+      // Lift the header (and its faint title watermark, which spills below the row) above the grid so
+      // the cards don't occlude it.
+      zIndex: 1,
     }),
     [insets.top],
   );

--- a/components/library-grid.tsx
+++ b/components/library-grid.tsx
@@ -10,7 +10,7 @@ import { isFolder } from "@/services/jellyfinApi";
 import { FolderStackEntry, JellyfinItem } from "@/types/jellyfin";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { ActivityIndicator, findNodeHandle, FlatList, Platform, Pressable, StyleSheet, Text, TVFocusGuideView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -83,32 +83,6 @@ export function LibraryGrid({
   const [filtersButtonHandle, setFiltersButtonHandle] = useState<number | undefined>(undefined);
   const handleFiltersButtonRef = useCallback((node: View | null) => setFiltersButtonHandle(getNativeHandle(node)), []);
 
-  // Node of the grid's first card, so focus can be re-asserted on it once the Filters-button handle is
-  // wired (see the re-anchor effect below). Mirrors app/(tabs)/search.tsx's firstResultRef.
-  const firstCardNodeRef = useRef<View | null>(null);
-  const firstCardRef = useCallback((node: View | null) => {
-    firstCardNodeRef.current = node;
-  }, []);
-  const didReanchorRef = useRef(false);
-
-  // tvOS focus fix. When a folder hydrates straight from the cache (items present on the very first
-  // render), the first card claims hasTVPreferredFocus — which fires on MOUNT only — BEFORE the header
-  // reports its Filters-button node, so tvOS builds that card's focus environment with no upward
-  // target. The handle arrives a render later, but tvOS never re-reads nextFocusUp for an
-  // already-focused view, so inside the grid's trapFocusUp pressing Up has nowhere to go and focus is
-  // dropped (the intermittent "stuck, Filters unreachable until restart" bug — reproduces only when the
-  // empty/loading state is skipped). Once the handle is wired, re-assert focus on the first card so
-  // tvOS rebuilds its environment WITH nextFocusUp. One-shot per mount: never steals focus during
-  // pagination or heart re-annotation. When the loading/empty state renders first the button node is
-  // captured before any card focuses, so this is a harmless no-op there.
-  useEffect(() => {
-    if (!IS_TV || !isInsideFolder || didReanchorRef.current) return;
-    if (filtersButtonHandle === undefined || items.length === 0) return;
-    didReanchorRef.current = true;
-    const node = firstCardNodeRef.current as unknown as { requestTVFocus?: () => void } | null;
-    node?.requestTVFocus?.();
-  }, [filtersButtonHandle, isInsideFolder, items.length]);
-
   // Pick the grid's slot shape from the folder's dominant content orientation.
   const slotOrientation = useMemo<SlotOrientation>(() => {
     const rated = items.filter((i) => i.PrimaryImageAspectRatio != null);
@@ -128,6 +102,27 @@ export function LibraryGrid({
     [insets.top, insets.bottom],
   );
 
+  // Folder grid: the Filters/breadcrumb bar is a pinned sibling above the list (it owns the top
+  // clearance), so the list itself starts just below it — no +insets.top/+80 here. The columnWrapper's
+  // paddingVertical gives the first row its gap.
+  const folderGridContentStyle = useMemo(
+    () => ({
+      ...styles.gridContent,
+      paddingBottom: TAB_BAR_HEIGHT + insets.bottom + 20,
+    }),
+    [insets.bottom],
+  );
+
+  // Tight top clearance for the pinned, floating folder header — just enough to clear the top edge,
+  // no tall dead space above the Filters button / breadcrumb.
+  const folderHeaderWrapStyle = useMemo(
+    () => ({
+      paddingTop: (Platform.isTV ? 40 : 16) + insets.top,
+      paddingLeft: Platform.isTV ? 80 : 60,
+    }),
+    [insets.top],
+  );
+
   // Focus-only (no blur→clear): on tvOS the incoming card's onFocus can fire before the outgoing
   // card's onBlur, so clearing on blur would race and cancel the new poster. Keep the last poster.
   const handleItemFocus = useCallback(
@@ -144,7 +139,6 @@ export function LibraryGrid({
       if (isFolder(item)) {
         return (
           <FolderGridItem
-            ref={index === 0 ? firstCardRef : undefined}
             folder={item}
             onPress={onItemPress}
             index={index}
@@ -157,7 +151,6 @@ export function LibraryGrid({
       }
       return (
         <VideoGridItem
-          ref={index === 0 ? firstCardRef : undefined}
           video={item}
           onPress={onItemPress}
           onLongPress={onItemLongPress}
@@ -169,7 +162,7 @@ export function LibraryGrid({
         />
       );
     },
-    [onItemPress, slotOrientation, handleItemFocus, onItemLongPress, isInsideFolder, numColumns, filtersButtonHandle, firstCardRef],
+    [onItemPress, slotOrientation, handleItemFocus, onItemLongPress, isInsideFolder, numColumns, filtersButtonHandle],
   );
 
   const renderFooter = useCallback(() => {
@@ -265,42 +258,60 @@ export function LibraryGrid({
     />
   ) : null;
 
+  const grid = (
+    <FlatList
+      testID="library-list"
+      data={items}
+      renderItem={renderItem}
+      keyExtractor={(item) => item.Id}
+      numColumns={numColumns}
+      key={numColumns}
+      contentContainerStyle={isInsideFolder ? folderGridContentStyle : gridContentStyle}
+      columnWrapperStyle={styles.columnWrapper}
+      // Folder: the Filters bar is a pinned sibling (below), NOT a list header. Root: keep the heading.
+      ListHeaderComponent={isInsideFolder ? undefined : <Text style={styles.serverHeading}>Libraries</Text>}
+      showsVerticalScrollIndicator={true}
+      updateCellsBatchingPeriod={50}
+      initialNumToRender={Platform.isTV ? 15 : 12}
+      maxToRenderPerBatch={Platform.isTV ? 15 : 12}
+      windowSize={5}
+      contentInsetAdjustmentBehavior="never"
+      removeClippedSubviews={false}
+      onEndReached={handleLoadMore}
+      onEndReachedThreshold={0.5}
+      ListFooterComponent={renderFooter}
+    />
+  );
+
   const inner =
     items.length === 0 ? (
-      <View style={[styles.container, { paddingTop: (Platform.isTV ? 20 : 10) + insets.top + 80, paddingLeft: Platform.isTV ? 80 : 60 }]}>
+      // Same tight top clearance as the loaded header so the Filters button doesn't jump when a
+      // folder finishes loading (loading/empty → populated).
+      <View style={[styles.container, folderHeaderWrapStyle]}>
         {folderHeader}
         {renderEmpty()}
       </View>
+    ) : isInsideFolder ? (
+      <View style={styles.container}>
+        {/* Pinned Filters/breadcrumb bar: a sibling ABOVE the list, always mounted, never scrolls off.
+            Up from the top row reaches it via nextFocusUp — the search.tsx pattern that sidesteps the
+            native scroll-focus gate (an off-top list header is unfocusable, so it can't be an up-target).
+            Transparent (floats over the ambient canvas); tight top clearance, no heavy chrome. */}
+        <View style={folderHeaderWrapStyle}>{folderHeader}</View>
+        {grid}
+      </View>
     ) : (
-      <FlatList
-        testID="library-list"
-        data={items}
-        renderItem={renderItem}
-        keyExtractor={(item) => item.Id}
-        numColumns={numColumns}
-        key={numColumns}
-        contentContainerStyle={gridContentStyle}
-        columnWrapperStyle={styles.columnWrapper}
-        ListHeaderComponent={isInsideFolder ? folderHeader : <Text style={styles.serverHeading}>Libraries</Text>}
-        showsVerticalScrollIndicator={true}
-        updateCellsBatchingPeriod={50}
-        initialNumToRender={Platform.isTV ? 15 : 12}
-        maxToRenderPerBatch={Platform.isTV ? 15 : 12}
-        windowSize={5}
-        contentInsetAdjustmentBehavior="never"
-        removeClippedSubviews={false}
-        onEndReached={handleLoadMore}
-        onEndReachedThreshold={0.5}
-        ListFooterComponent={renderFooter}
-      />
+      grid
     );
 
   return (
     <View style={styles.container}>
       <AmbientBackground dynamic />
-      {/* Inside a folder, trap upward focus so pressing Up from the top grid row stays on the screen
-          instead of escaping to the native tab bar — focusing the active tab pops the nested Stack
-          back to the libraries root. Root keeps normal Up-to-tab-bar behavior for switching tabs. */}
+      {/* Inside a folder: trapFocusUp keeps Up from the top row from escaping to the native tab bar
+          (which would pop the nested Stack). No autoFocus/destinations — the pinned Filters bar is an
+          always-mounted sibling reached deterministically via nextFocusUp from the top row, so the
+          focus environment never depends on guide recovery (unreliable on Fabric/tvOS after first use).
+          Root keeps normal Up-to-tab-bar behavior for switching tabs. */}
       {isInsideFolder && IS_TV ? (
         <TVFocusGuideView style={styles.container} trapFocusUp>
           {inner}

--- a/components/library-grid.tsx
+++ b/components/library-grid.tsx
@@ -119,9 +119,6 @@ export function LibraryGrid({
     () => ({
       paddingTop: (Platform.isTV ? 40 : 16) + insets.top,
       paddingLeft: Platform.isTV ? 80 : 60,
-      // Lift the header (and its faint title watermark, which spills below the row) above the grid so
-      // the cards don't occlude it.
-      zIndex: 1,
     }),
     [insets.top],
   );
@@ -331,8 +328,9 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   gridContent: {
+    // Symmetric horizontal padding so the content column is centered under the (OS-centered) tab bar.
     paddingLeft: Platform.isTV ? 80 : 60,
-    paddingRight: Platform.isTV ? 40 : 20,
+    paddingRight: Platform.isTV ? 80 : 60,
   },
   columnWrapper: {
     justifyContent: "flex-start",

--- a/components/library-header.tsx
+++ b/components/library-header.tsx
@@ -17,6 +17,8 @@ interface LibraryHeaderProps {
   activeFilterCount?: number;
   /** Give the Filters button TV preferred focus (empty grids: it is the screen's focus anchor). */
   filtersButtonHasPreferredFocus?: boolean;
+  /** Reports the Filters button's native node so the grid can target it with nextFocusUp. */
+  onFiltersButtonRef?: (node: View | null) => void;
 }
 
 /**
@@ -33,9 +35,15 @@ interface LibraryHeaderProps {
  * full-width bar and gets redirected to the button, so it is reachable regardless of how many
  * items the grid has or which column is focused.
  */
-function LibraryHeaderComponent({ stack, onBack, onOpenFilters, activeFilterCount = 0, filtersButtonHasPreferredFocus = false }: LibraryHeaderProps) {
+function LibraryHeaderComponent({ stack, onBack, onOpenFilters, activeFilterCount = 0, filtersButtonHasPreferredFocus = false, onFiltersButtonRef }: LibraryHeaderProps) {
   const [filtersButtonNode, setFiltersButtonNode] = useState<View | null>(null);
-  const filtersButtonRef = useCallback((node: View | null) => setFiltersButtonNode(node), []);
+  const filtersButtonRef = useCallback(
+    (node: View | null) => {
+      setFiltersButtonNode(node);
+      onFiltersButtonRef?.(node);
+    },
+    [onFiltersButtonRef],
+  );
 
   if (stack.length === 0) {
     return null;
@@ -58,7 +66,7 @@ function LibraryHeaderComponent({ stack, onBack, onOpenFilters, activeFilterCoun
 
   if (IS_TV) {
     return (
-      <TVFocusGuideView style={styles.tvContainer} destinations={filtersButtonNode ? [filtersButtonNode] : []}>
+      <TVFocusGuideView style={styles.tvContainer} destinations={filtersButtonNode ? [filtersButtonNode] : undefined}>
         {filtersButton}
         <View style={styles.tvPath} pointerEvents="none">
           {stack.map((entry, index) => {

--- a/components/library-header.tsx
+++ b/components/library-header.tsx
@@ -1,3 +1,4 @@
+import { FiltersGhostTitle } from "@/components/filters-ghost-title";
 import { FocusableButton } from "@/components/FocusableButton";
 import { FolderStackEntry } from "@/types/jellyfin";
 import { Ionicons } from "@expo/vector-icons";
@@ -65,6 +66,9 @@ function LibraryHeaderComponent({ stack, onBack, onOpenFilters, activeFilterCoun
   if (IS_TV) {
     return (
       <View style={styles.tvContainer}>
+        {/* Faint oversized library name behind the controls — the header's ambient title. Spills down
+            out of the row (top-anchored), clipped at the right edge; never intercepts focus. */}
+        <FiltersGhostTitle name={stack[0]?.name ?? ""} variant="header" />
         {filtersButton}
         <View style={styles.tvPath} pointerEvents="none">
           {stack.map((entry, index) => {
@@ -111,6 +115,7 @@ const styles = StyleSheet.create({
     gap: 24,
     marginLeft: 16,
     marginBottom: 4,
+    paddingBottom: 14,
   },
   tvPath: {
     flexDirection: "row",

--- a/components/library-header.tsx
+++ b/components/library-header.tsx
@@ -1,8 +1,8 @@
 import { FocusableButton } from "@/components/FocusableButton";
 import { FolderStackEntry } from "@/types/jellyfin";
 import { Ionicons } from "@expo/vector-icons";
-import React, { useCallback, useState } from "react";
-import { Platform, Pressable, StyleSheet, Text, TVFocusGuideView, View } from "react-native";
+import React, { useCallback } from "react";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 
 const IS_TV = Platform.isTV;
 
@@ -30,16 +30,14 @@ interface LibraryHeaderProps {
  *   navigation Stack natively.
  * - Touch (iOS/Android phone): a tappable "‹ CurrentFolder" row, since touch has no back key.
  *
- * On TV the whole bar is a TVFocusGuideView whose destination is the right-aligned Filters
- * button: pressing Up from ANY grid card (or the empty-state focus holder) exits into the
- * full-width bar and gets redirected to the button, so it is reachable regardless of how many
- * items the grid has or which column is focused.
+ * On TV this bar is a plain row rendered as a pinned sibling ABOVE the folder grid (not a list
+ * header), so it never scrolls off-screen. The grid routes Up from its top row straight to the
+ * right-aligned Filters button via nextFocusUp (the button reports its native node through
+ * onFiltersButtonRef) — no focus guide/destinations, which are unreliable on Fabric/tvOS.
  */
 function LibraryHeaderComponent({ stack, onBack, onOpenFilters, activeFilterCount = 0, filtersButtonHasPreferredFocus = false, onFiltersButtonRef }: LibraryHeaderProps) {
-  const [filtersButtonNode, setFiltersButtonNode] = useState<View | null>(null);
   const filtersButtonRef = useCallback(
     (node: View | null) => {
-      setFiltersButtonNode(node);
       onFiltersButtonRef?.(node);
     },
     [onFiltersButtonRef],
@@ -66,7 +64,7 @@ function LibraryHeaderComponent({ stack, onBack, onOpenFilters, activeFilterCoun
 
   if (IS_TV) {
     return (
-      <TVFocusGuideView style={styles.tvContainer} destinations={filtersButtonNode ? [filtersButtonNode] : undefined}>
+      <View style={styles.tvContainer}>
         {filtersButton}
         <View style={styles.tvPath} pointerEvents="none">
           {stack.map((entry, index) => {
@@ -81,7 +79,7 @@ function LibraryHeaderComponent({ stack, onBack, onOpenFilters, activeFilterCoun
             );
           })}
         </View>
-      </TVFocusGuideView>
+      </View>
     );
   }
 

--- a/components/video-grid-item.tsx
+++ b/components/video-grid-item.tsx
@@ -1,4 +1,6 @@
+import { CardNavProgress } from "@/components/card-nav-progress";
 import { CARD_FOCUS, DESIGN, GRID, slotColumns, slotRatio, type SlotOrientation } from "@/constants/app";
+import { useCardNavProgress } from "@/hooks/useCardNavProgress";
 import { getPosterUrl, hasPoster } from "@/services/jellyfinApi";
 import { JellyfinVideoItem } from "@/types/jellyfin";
 import { Ionicons } from "@expo/vector-icons";
@@ -46,6 +48,7 @@ const VideoGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpaci
   ref,
 ) {
   const [focused, setFocused] = useState(false);
+  const { navigating, startNavProgress, resetNavProgress } = useCardNavProgress();
 
   // Poster source with a STABLE cache key: keyed by item id + image tag + size,
   // independent of the api_key/token in the URL. This keeps the disk/memory cache
@@ -82,11 +85,13 @@ const VideoGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpaci
 
   const handleBlur = useCallback(() => {
     setFocused(false);
-  }, []);
+    resetNavProgress();
+  }, [resetNavProgress]);
 
   const handlePress = useCallback(() => {
+    startNavProgress();
     onPress(video);
-  }, [onPress, video]);
+  }, [onPress, video, startNavProgress]);
 
   const handleLongPress = useCallback(() => {
     onLongPress?.(video);
@@ -165,6 +170,9 @@ const VideoGridItemComponent = forwardRef<React.ElementRef<typeof TouchableOpaci
 
           {/* Border overlay - rendered on top to avoid gaps */}
           <View style={[styles.borderOverlay, focused && styles.borderOverlayFocused]} pointerEvents="none" />
+
+          {/* Per-card feedback while the pressed card's destination loads. */}
+          <CardNavProgress active={navigating} />
         </View>
       </View>
     </TouchableOpacity>

--- a/hooks/useCardNavProgress.ts
+++ b/hooks/useCardNavProgress.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// If focus never leaves the card (navigation failed, or nothing stole focus), clear the bar anyway so
+// it can't stick on screen.
+const SAFETY_TIMEOUT_MS = 5000;
+
+/**
+ * Card-local "navigation in progress" state for the per-card progress bar. A card calls
+ * `startNavProgress()` on press and `resetNavProgress()` when it loses focus — on tvOS the destination
+ * screen grabbing focus blurs the source card, which is the natural handoff that brackets the load
+ * gap. A safety timeout guarantees the bar never sticks if focus never leaves.
+ */
+export function useCardNavProgress() {
+  const [navigating, setNavigating] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const startNavProgress = useCallback(() => {
+    clearTimer();
+    setNavigating(true);
+    timeoutRef.current = setTimeout(() => setNavigating(false), SAFETY_TIMEOUT_MS);
+  }, [clearTimer]);
+
+  const resetNavProgress = useCallback(() => {
+    clearTimer();
+    setNavigating(false);
+  }, [clearTimer]);
+
+  // Clear any pending timer on unmount.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  return { navigating, startNavProgress, resetNavProgress };
+}

--- a/memories/CLAUDE-lessons-learned.md
+++ b/memories/CLAUDE-lessons-learned.md
@@ -817,3 +817,59 @@ The gates are server config a non-admin client cannot read (`/System/Configurati
 - `services/jellyfinApi.ts` (`updateUserItemData`; `fetchResumeItems` MediaTypes=Video,Audio)
 - `hooks/usePlaybackReporter.ts` (`persistResumePosition` after each position-bearing report)
 - `hooks/useVideoPlayback.ts` (`wasPlayedAtStartRef` captured once per video)
+
+---
+
+## tvOS — Up From a Folder Grid Card Loses Focus, Filters Button Unreachable (July 2026)
+
+### Problem
+
+Inside a Library folder on Apple TV, pressing **Up** from a grid card intermittently fails to reach the Filters button: focus is dropped, the Filters CTA becomes unfocusable, Down lands on a lower card, and it stays broken until a hard app restart. Worse on Movies (landscape, 4 cols) than Music (portrait, 6 cols). Not reproducible on demand.
+
+### Root Cause (CONFIRMED)
+
+Two layers, both largely OUTSIDE our JS:
+
+1. **Native focus traversal.** react-native-tvos overrides UIKit's ScrollView focus gate. In the installed **0.85.0-0**, `node_modules/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm:1391-1396` (`shouldUpdateFocusInContext:`): when the list is scrolled (`contentOffset.y > 0`) and Up is pressed, it returns `containsEnvironment:context.nextFocusedItem` — i.e. **blocks the focus move unless the target is inside this scroll view**. This is the same gate as the Jan 2026 "tvOS FlatList Focus Escape Bug". Our Filters button was the FlatList's `ListHeaderComponent` — inside the scroll view but scrolled off-top (and an off-screen view isn't focusable), so Up fails; `trapFocusUp` then has no valid target and swallows the press, leaving focus dead until the process restarts.
+
+2. **Unfixed rn-tvos New-Architecture bugs** (Expo 56 = Fabric): `hasTVPreferredFocus` fails after first use on tvOS (upstream #849), fails under react-navigation native-stack (#670 — expo-router IS native-stack), and snaps focus inside ScrollViews (#839). `components/library-grid.tsx` used `hasTVPreferredFocus={index === 0}` unconditionally on every folder mount → all three. TVFocusGuideView `destinations`/`autoFocus` are also unreliable after first load / under new arch (#204, #815).
+
+**Why `app/(tabs)/search.tsx` never breaks (the reliable template):** its up-target (search box) is a **sibling OUTSIDE the FlatList**, always mounted, reached only from the top row where `contentOffset.y === 0` (gate defers to super); it gates `hasTVPreferredFocus` on `shouldShowResults`, sets the handle synchronously in the ref callback, and uses NO `trapFocusUp`. It structurally avoids every failure mode.
+
+**Why intermittent + Movies-worse:** first mount works (#849), later navigations corrupt the focus env; landscape overflows the viewport sooner → `contentOffset.y > 0` far more often.
+
+### Solution
+
+Not yet landed (root cause confirmed; fix carries a design tradeoff, so left to a deliberate decision). Direction: mirror search.tsx — render the folder header as a **sibling outside the FlatList** (always-mounted, reachable from the top row), gate `hasTVPreferredFocus` on `items.length > 0`, drop the `requestTVFocus` re-anchor. Note: this pins the Filters/breadcrumb bar (no longer scrolls away) — a visible change the user rejected once. The definitive belt-and-suspenders option is a `patch-package` patch to the native gate (per the Jan 2026 entry), requiring `npm run prebuild:tv` + rebuild.
+
+### What Went Wrong
+
+- ❌ Fixed focus **position** (requestTVFocus re-anchor, hasTVPreferredFocus tweaks, "button holds initial focus") four times while the real bug is in focus **traversal** — native, not JS. Every JS-only attempt failed intermittently, exactly as the Jan 2026 entry warned.
+- ❌ Ignored the repo's OWN lessons-learned, which already documented this native gate and that JS fixes don't work.
+- ❌ "Verified" a fix from a single sim screenshot instead of a hammer test — the bug is intermittent, so one success proved nothing.
+- ❌ Added `flex:1` to the FlatList when moving the header to a sibling → blanked the screen (search's list has no flex).
+
+### What Worked
+
+- ✅ Reading the installed native `.mm` and confirming the gate exists at the exact lines in 0.85.0-0.
+- ✅ Cross-referencing upstream react-native-tvos issues (#849/#670/#839/#204/#815) to explain the intermittency and the Fabric/native-stack triggers.
+- ✅ Diffing against `search.tsx` (the one reliable focus screen) to see the structural difference: up-target inside vs outside the scroll view.
+
+### Key Takeaways
+
+1. **tvOS focus bugs are usually native traversal bugs, not JS position bugs.** If Up/Down/Left/Right can't GO somewhere, look at `RCTScrollViewComponentView.mm:shouldUpdateFocusInContext:` and the VC hierarchy — not `hasTVPreferredFocus`/`requestTVFocus`.
+2. A `nextFocusUp` target must be **always-mounted and on-screen**. A `ListHeaderComponent` scrolls off and becomes unreachable; put the target OUTSIDE the FlatList (sibling), like search.tsx.
+3. On new-arch (Fabric) tvOS, **do not rely on `hasTVPreferredFocus` past initial mount** (fails after first use / with native-stack / in ScrollViews). Gate it, and prefer imperative `requestTVFocus` from `useFocusEffect`.
+4. Intermittent focus bugs require an on-device **hammer test** (many nav cycles), never a single screenshot.
+5. Check THIS file first for any tvOS focus work — the native gate was already documented in Jan 2026.
+
+### Files Relevant
+
+- `node_modules/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm:1368-1399` (native gate)
+- `components/library-grid.tsx` (Filters button as ListHeaderComponent; unconditional `hasTVPreferredFocus`; `trapFocusUp`)
+- `components/library-header.tsx` (`destinations` guide)
+- `app/(tabs)/search.tsx` (the reliable template: sibling header, gated focus, no trap)
+
+### Status
+
+Root cause CONFIRMED. Fix pending a design decision (pin the Filters bar via the search-mirror JS change, and/or `patch-package` the native gate). Codebase reset to commit `4f6b85b`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1571,15 +1571,15 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "56.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-56.0.11.tgz",
-      "integrity": "sha512-Rt3U9Rqr6midz/sDeubFN5fefR0KzHpcEEgAUnV98XsLSSTnfzIxoC1blICb7pUUscKc8TtlVyn7/Gita2wnOQ==",
+      "version": "56.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-56.0.12.tgz",
+      "integrity": "sha512-8X+FtflatWdFqBFlPxtyNRaj2dzMCPzi5wImO8IbhOLRKQVWyXdoLb26j0WjpWZaN1qo3Kf90t5yIcWdbbnfVA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~56.0.11",
+        "@expo/config-plugins": "~56.0.13",
         "@expo/config-types": "^56.0.7",
         "@expo/json-file": "^10.2.0",
-        "@expo/require-utils": "^56.1.4",
+        "@expo/require-utils": "^56.1.5",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -1589,15 +1589,15 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "56.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.12.tgz",
-      "integrity": "sha512-UKjPEOkvxBzTvjghmjUECURDoJLPJIFIevB0JQCe8l9Fg4yfy2fabU5LU3Kfrmmu1/8et/93bucCnABEmoxYEw==",
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.13.tgz",
+      "integrity": "sha512-BWtRkvUKLb4xaMLTRXmrHPHl+RI5nKF2MKJEXODHmLtVgUlXOz66XSCU4bEvjfr8yYTx+8DQ0JO54Y7Y0kwokA==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^56.0.7",
         "@expo/json-file": "~10.2.0",
         "@expo/plist": "^0.7.0",
-        "@expo/require-utils": "^56.1.4",
+        "@expo/require-utils": "^56.1.5",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -1815,9 +1815,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.4.1.tgz",
-      "integrity": "sha512-3c9Mg9x0HmGPEsVrGAGyEDJsNUOZ55cZvZ47/HLmXh7MHV9Zv7My73wThklKrObaBBoMfE4YqpKjYKDRzojpjQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.4.2.tgz",
+      "integrity": "sha512-28pqaEqwnmLduZ00Pq9HkSzE5wbj1MTwp5/n8nm8rD8MCjR9eUnVOwmNksPI3Be2ReAPO/DbPn1puy0mvoocsQ==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -1844,9 +1844,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.19.7.tgz",
-      "integrity": "sha512-Q04NyJE0E7qKGXepBjI8e0p983RrQGBWJcSICKyyLczsr5JhNuSmqw604aL7koaXG2ctrUL36qd332XiMS/s6w==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.19.8.tgz",
+      "integrity": "sha512-zM0UMJLxYJnYq0+IzASGUYwQulENnC4qmXCAwJYmjD66AG+qTfyab4yTmL2gbiWyBAsWv0vPtP+ahEhtsT2CjQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "^2.3.1",
@@ -1940,12 +1940,12 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.10.2.tgz",
-      "integrity": "sha512-qQUGaacqXduoFTCUQAMceIWYzlKU0xX4/BKTyh8TdVj0uHv9/W3MfHOy5yXoOqBVrSccXk++Gm4D/NfS5HnCNA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.10.3.tgz",
+      "integrity": "sha512-FgVp21Q05GRi08XwkzdZbBb/sBgCcP66snxlyN/HyisdtTcSbTr1qV5wkXYjq+6Q1xllXiKLmCwjDvydoN2vyg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^56.1.4",
+        "@expo/require-utils": "^56.1.5",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
@@ -1976,12 +1976,12 @@
       }
     },
     "node_modules/@expo/inline-modules": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.13.tgz",
-      "integrity": "sha512-26RllWesRmYsAAo70cRcR9DaqXPKJct9MIGxZteS+Tkg25ljOkFeG7fYEsSazZOLpAslKBiilqtZykVYrxSzCw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/inline-modules/-/inline-modules-0.0.14.tgz",
+      "integrity": "sha512-jHrqsgpb5QnnwGfxD6NrUAMW9JcS1+j/e8GiLSy+12Md7aRnEWqi347xZ8Q57tkow1iXdeVLXPeyn1VmmCB8fA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~56.0.11"
+        "@expo/config-plugins": "~56.0.13"
       }
     },
     "node_modules/@expo/json-file": {
@@ -1995,12 +1995,12 @@
       }
     },
     "node_modules/@expo/local-build-cache-provider": {
-      "version": "56.0.9",
-      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-56.0.9.tgz",
-      "integrity": "sha512-VMJC5ul7dXPfD2OO16ObPi6ym4H8vlnCBUuCM/KeKh0OvLRub35X8OB2uYrFQ+vbWkPemAEOWvk0oOptpPxbzA==",
+      "version": "56.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-56.0.10.tgz",
+      "integrity": "sha512-ki4bnpcWaZRfOdcN1TYLuN02k+R8UaUJ9rQuSOKlj471ZnDcrAn/muugA8xHiIbZ/hS5HGNIy5z5A/unTPjVUw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~56.0.11",
+        "@expo/config": "~56.0.12",
         "chalk": "^4.1.2"
       }
     },
@@ -2044,19 +2044,19 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "56.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.16.tgz",
-      "integrity": "sha512-mxPZ23exC6kkEpPYQOteamaiWYER3uDk2IqKys7EJwtIKc3F1207Xtsdko/DNNG04DLwpN/WM2UlNl+Ak8uPRg==",
+      "version": "56.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.17.tgz",
+      "integrity": "sha512-kxCDDCTPbd29gqVhic7fGAPzXbW+fNWerDeXNJdaoO7rutEwogEeud7UHpX4G0fZNMbio1eM5mAQa+edCm/IRw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~56.0.11",
+        "@expo/config": "~56.0.12",
         "@expo/env": "~2.3.1",
         "@expo/json-file": "~10.2.0",
         "@expo/metro": "~56.0.0",
-        "@expo/require-utils": "^56.1.4",
+        "@expo/require-utils": "^56.1.5",
         "@expo/spawn-async": "^1.8.0",
         "@jridgewell/gen-mapping": "^0.3.13",
         "@jridgewell/remapping": "^2.3.5",
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@expo/metro-runtime": {
-      "version": "56.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-56.0.16.tgz",
-      "integrity": "sha512-UsKrBLOCa+kAVHW1S0HdGkM0hkiQXeh3fZIpjcriOmoNg/CVRgdKQhUxUkNoXAoPfT85uW1x2fzNbiYhPQO1SA==",
+      "version": "56.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-56.0.17.tgz",
+      "integrity": "sha512-mYZXMOX3SYqF4VC4G3eVq8+Hd0YfEjs/sSf2eKpqJl54fDtBxeJIu5DLHg9YIMsICPhUZ/r73syEm0835ZEM+g==",
       "license": "MIT",
       "dependencies": {
         "@expo/log-box": "^56.0.14",
@@ -2198,9 +2198,9 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.0.tgz",
-      "integrity": "sha512-wKIXL8UtbuX4KwavPasIW3CUcgTbYfjzLcgUhjyKUAYDEqMaf6gmU1bqz3ffBPTokmX+G8/vFG1ZuI9etQWukA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.1.tgz",
+      "integrity": "sha512-Zn03EX6In7ts2lPUW2ESUSkEhEWQN1qqsiXjadtZMJOuZRkMiAg1ZQHuvz9DjByDWNJ2pBwAGyrts9lj9k389g==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.8.0"
@@ -2210,12 +2210,12 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.0.tgz",
-      "integrity": "sha512-s3W3eZafJDEyVL7W/jxj2Nz3eONKxSCU604S5xj8ijrVaRz83x0DnZznLf/UXQEI1w+FyibH68nHeQyk767b1A==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.1.tgz",
+      "integrity": "sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^11.0.0",
+        "@expo/json-file": "^11.0.1",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@expo/package-manager/node_modules/@expo/json-file": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.0.tgz",
-      "integrity": "sha512-pHJCETqFL5x5BzNV6cEPwjwuECgGmnl0bNmfHIJ6LM1tlh2eVXi5HEdit3zby/JO/B8Otk5cgcqtJXgvvUat3A==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
+      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2245,19 +2245,19 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "56.0.19",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.19.tgz",
-      "integrity": "sha512-aP/7kGDPMmwY9C9cYMK4MfUiZk23KhN4AfnKz0eeRyg3Izw0OGdtzNDLIcchnqpDAwHsI0+LUHZhucGl1jQJ5A==",
+      "version": "56.0.20",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-56.0.20.tgz",
+      "integrity": "sha512-S8K1lg1cqREpnUtWAhDSOitTVJssFVhJAAdtNSi1mZaG/HL5QHUB+dogHIHijfdWKBj4KPGGjBfo6GqdmzzgtA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~56.0.11",
-        "@expo/config-plugins": "~56.0.12",
+        "@expo/config": "~56.0.12",
+        "@expo/config-plugins": "~56.0.13",
         "@expo/config-types": "^56.0.7",
-        "@expo/image-utils": "^0.10.2",
+        "@expo/image-utils": "^0.10.3",
         "@expo/json-file": "^10.2.0",
         "@react-native/normalize-colors": "0.85.3",
         "debug": "^4.3.1",
-        "expo-modules-autolinking": "~56.0.19",
+        "expo-modules-autolinking": "~56.0.20",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       }
@@ -2281,9 +2281,9 @@
       }
     },
     "node_modules/@expo/require-utils": {
-      "version": "56.1.4",
-      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.4.tgz",
-      "integrity": "sha512-IX7XXg9obnrH3ni0TClBbVKgqk0nT0bjTEPTBtbD+WgIeZ0hpcgwxMJH3j5uBsUqEAq1jqUAkJWrPcg7ZRSV7g==",
+      "version": "56.1.5",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.5.tgz",
+      "integrity": "sha512-3wsdJLSpELhRPEMZCCREqAAFRGG23BUWJHGKIUxyqGkWvy5KPdzlBxGlVVb/6h9gNOflqgTtvTWaP2EuHoQ1HQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2330,9 +2330,9 @@
       "license": "MIT"
     },
     "node_modules/@expo/ui": {
-      "version": "56.0.21",
-      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-56.0.21.tgz",
-      "integrity": "sha512-DosrgEiDqxc/tPH39/Nf5BmVxdeJ616xk/ihu7CJ7Xuzkr79E6/fp4IA15KzBiTdJeH3id1adhIwj8RX1jnh6A==",
+      "version": "56.0.22",
+      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-56.0.22.tgz",
+      "integrity": "sha512-B6CXc+WJg2GE4KF6LrCPTf+ozMWKMG9TAVc//gQYUsLzFZzm0vCgUqXRiaNJ6BukpHoZPLKsQZ95VsSyTVda3A==",
       "license": "MIT",
       "dependencies": {
         "sf-symbols-typescript": "^2.1.0",
@@ -6431,9 +6431,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -7401,31 +7401,31 @@
       }
     },
     "node_modules/expo": {
-      "version": "56.0.15",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.15.tgz",
-      "integrity": "sha512-Tnas9Sq1fDY865rhSQ4266Kd4GULEUyBEBEchbNLQsiY6U+AAt4MgCKJUsRvUkNHdaZwnGzexy6hdnOjsgvNcA==",
+      "version": "56.0.16",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-56.0.16.tgz",
+      "integrity": "sha512-6G1yfBKG3J16HBgF2ehdd1iZBlRmbDF/lB7SG30v4jojgvN03HZkENHujKfuGuBqDBlzkkXjZvpxRVvIUQTAMQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "^56.1.19",
-        "@expo/config": "~56.0.11",
-        "@expo/config-plugins": "~56.0.12",
+        "@expo/cli": "^56.1.20",
+        "@expo/config": "~56.0.12",
+        "@expo/config-plugins": "~56.0.13",
         "@expo/devtools": "~56.0.2",
         "@expo/dom-webview": "~56.0.6",
-        "@expo/fingerprint": "^0.19.7",
-        "@expo/local-build-cache-provider": "^56.0.9",
+        "@expo/fingerprint": "^0.19.8",
+        "@expo/local-build-cache-provider": "^56.0.10",
         "@expo/log-box": "^56.0.14",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~56.0.16",
+        "@expo/metro-config": "~56.0.17",
         "@ungap/structured-clone": "^1.3.0",
         "babel-preset-expo": "~56.0.17",
-        "expo-asset": "~56.0.19",
-        "expo-constants": "~56.0.20",
+        "expo-asset": "~56.0.20",
+        "expo-constants": "~56.0.21",
         "expo-file-system": "~56.0.8",
         "expo-font": "~56.0.7",
         "expo-keep-awake": "~56.0.3",
-        "expo-modules-autolinking": "~56.0.19",
-        "expo-modules-core": "~56.0.20",
+        "expo-modules-autolinking": "~56.0.20",
+        "expo-modules-core": "~56.0.21",
         "pretty-format": "^29.7.0",
         "react-refresh": "^0.14.2",
         "whatwg-url-minimum": "^0.1.2"
@@ -7463,13 +7463,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "56.0.19",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.19.tgz",
-      "integrity": "sha512-huGY0bVfYUivNOir+iUEjjW9IbNHzLFNo8d6FGh22u1OsXcFR7Za3vpu5V1gMp0dc31wiqmsXkTazjm+Rro3vA==",
+      "version": "56.0.20",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.20.tgz",
+      "integrity": "sha512-pjVw3JDiaq6Ee15UbDeZpiGNAHJqfOZwY61VPlFiznuuj7f/b2tvegujeIEu2+p6C2/tioZGGD6zWQuJ9Ob3uQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.10.2",
-        "expo-constants": "~56.0.20"
+        "@expo/image-utils": "^0.10.3",
+        "expo-constants": "~56.0.21"
       },
       "peerDependencies": {
         "expo": "*",
@@ -7478,9 +7478,9 @@
       }
     },
     "node_modules/expo-blur": {
-      "version": "56.0.3",
-      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-56.0.3.tgz",
-      "integrity": "sha512-KDDtrpWc2tYlm1WCPaOgBtv+YEGqe5ELheFPIgSNgHt28NQUDcfBcFsA9Us2StDh6osmSD6NbKxOt5bU6PcDbQ==",
+      "version": "56.0.4",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-56.0.4.tgz",
+      "integrity": "sha512-/rNpe2NDTmMbSktVJb5z7HoX6apYtq8KVKJNjWOQV7NG01+LvctWzFeMNxWSZVWfIKTndqdqABwqcpYmiCRxxg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -7489,9 +7489,9 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "56.0.20",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.20.tgz",
-      "integrity": "sha512-4HgoVvUiMvcqujr/CUj7L1tumLWj8WX0PLM77OriDPoaJrMEwUHd841m4o4IoUyMPVT8XTiTiPFwJtGali8+9Q==",
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.21.tgz",
+      "integrity": "sha512-q9LkK9tNTW2z/5hXgpwWoCXO1fBrqn4FgwTiLerM9WOu1wtg99NevAtG3BEG8t5Awtub+NsLidiFZzBat45RKw==",
       "license": "MIT",
       "dependencies": {
         "@expo/env": "~2.3.1"
@@ -7615,12 +7615,12 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "56.0.19",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.19.tgz",
-      "integrity": "sha512-ztzTzS21fbq4oJQItSgT+WWJMZXGsC0GdX/cDN/GBhCTPiZz8foHkVa14DiLa5CWd7pEZ9EeSMdHDcAEc2dZ5Q==",
+      "version": "56.0.20",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.20.tgz",
+      "integrity": "sha512-bIUaHtWlqQpculjhN1wERVBoVeRCefkW3zXY/SqiXSm/6uofZy3NRF1t5Co44lmBQczAs/lFR7BwA8lmUiGMnw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/require-utils": "^56.1.4",
+        "@expo/require-utils": "^56.1.5",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.1.0",
         "commander": "^7.2.0"
@@ -7630,9 +7630,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "56.0.20",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.20.tgz",
-      "integrity": "sha512-Xagwt/gC6sV1jiSnlFrYxLooZr90adLrpV64YlkXZjgZ6Kot89FF62e457RyejLtyDm2pOdy6FZphF1ReyK2Jw==",
+      "version": "56.0.21",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.21.tgz",
+      "integrity": "sha512-lT413DZFuX/cSsOqGtZnqtyCGlY3F3FFDiVhwzB8wX4Ei9HZYPXhV59Mm8SNJquo8+JfLRi3arv3z5U4MqJRcA==",
       "license": "MIT",
       "dependencies": {
         "@expo/expo-modules-macros-plugin": "0.2.2",
@@ -7660,15 +7660,15 @@
       }
     },
     "node_modules/expo-router": {
-      "version": "56.2.14",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-56.2.14.tgz",
-      "integrity": "sha512-zhJ0YgMxzosxPVTqPJTzTwOCvY06+uFJSW93vFYpF+AyMSZ/DCT+iQew0bwGky6dmWrrIjLBbZ/bv/CdaEdAEg==",
+      "version": "56.2.15",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-56.2.15.tgz",
+      "integrity": "sha512-VdPIBuJ0D2cv4gCulU5slhDlF9ocDNXsne03qu5AcTYROLIctlYDAzzLax7lSKZLP6GI6+Xw+I2dN7QMjC9UCA==",
       "license": "MIT",
       "dependencies": {
         "@expo/log-box": "^56.0.14",
-        "@expo/metro-runtime": "^56.0.16",
+        "@expo/metro-runtime": "^56.0.17",
         "@expo/schema-utils": "^56.0.2",
-        "@expo/ui": "^56.0.21",
+        "@expo/ui": "^56.0.22",
         "@radix-ui/react-slot": "^1.2.0",
         "@radix-ui/react-tabs": "^1.1.12",
         "@react-native-masked-view/masked-view": "^0.3.2",
@@ -7697,10 +7697,10 @@
       },
       "peerDependencies": {
         "@expo/log-box": "^56.0.14",
-        "@expo/metro-runtime": "^56.0.16",
+        "@expo/metro-runtime": "^56.0.17",
         "@testing-library/react-native": ">= 13.2.0",
         "expo": "*",
-        "expo-constants": "^56.0.20",
+        "expo-constants": "^56.0.21",
         "expo-linking": "^56.0.15",
         "react": "*",
         "react-dom": "*",
@@ -7752,13 +7752,13 @@
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "56.0.12",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-56.0.12.tgz",
-      "integrity": "sha512-RvEtJ78aNpuxdVD8TCe9viKtlYGzS9hW20fbvqvkeXDN6WAaYo1CRitPdjWNkaNNSPKOolp3zfha4EGdhXOtxg==",
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-56.0.13.tgz",
+      "integrity": "sha512-8+ytfHX4/B5sj97N4PIzm4IP/7uDbbYTsY/vOMWa7ASTVkGZB+pXB23dBwBu7TcKx5w9Wt0NkaPAwy6dhNEdag==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-plugins": "~56.0.11",
-        "@expo/image-utils": "^0.10.2",
+        "@expo/config-plugins": "~56.0.13",
+        "@expo/image-utils": "^0.10.3",
         "xml2js": "0.6.0"
       },
       "peerDependencies": {
@@ -7813,28 +7813,28 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "56.1.19",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.19.tgz",
-      "integrity": "sha512-k+oipwbu83WFnACtybvGZvDbbItarY4lfjkKgP9F5lml2ilvL/VvzsPhbhT7nRyFB3zPJq9SbNNKa45VDLoihA==",
+      "version": "56.1.20",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-56.1.20.tgz",
+      "integrity": "sha512-xWkKvOBkOE3G/PpU29fjmAjKpCIqTIVSxG8oA+E6pYUElcPZ9gRofAdTE321lUoJVHwEjKmpn93EHqsajItDTQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
-        "@expo/config": "~56.0.11",
-        "@expo/config-plugins": "~56.0.12",
+        "@expo/config": "~56.0.12",
+        "@expo/config-plugins": "~56.0.13",
         "@expo/devcert": "^1.2.1",
         "@expo/env": "~2.3.1",
-        "@expo/image-utils": "^0.10.2",
-        "@expo/inline-modules": "^0.0.13",
+        "@expo/image-utils": "^0.10.3",
+        "@expo/inline-modules": "^0.0.14",
         "@expo/json-file": "^10.2.0",
         "@expo/log-box": "^56.0.14",
         "@expo/metro": "~56.0.0",
-        "@expo/metro-config": "~56.0.16",
+        "@expo/metro-config": "~56.0.17",
         "@expo/metro-file-map": "^56.0.3",
         "@expo/osascript": "^2.6.0",
         "@expo/package-manager": "^1.12.1",
         "@expo/plist": "^0.7.0",
-        "@expo/prebuild-config": "^56.0.19",
-        "@expo/require-utils": "^56.1.4",
+        "@expo/prebuild-config": "^56.0.20",
+        "@expo/require-utils": "^56.1.5",
         "@expo/router-server": "^56.0.16",
         "@expo/schema-utils": "^56.0.2",
         "@expo/spawn-async": "^1.8.0",


### PR DESCRIPTION
Finalizes 1.7.0: the changes that landed after the release commit was cut. Fills in the 1.7.0 changelog.

## Focus (Apple TV)
- Up from the top grid row reliably reaches the Filters button: the header is a pinned sibling outside the FlatList (an off-screen list header is unfocusable under the native tvOS scroll-focus gate), targeted by `nextFocusUp`
- Focus is never lost when opening or returning to a loading/empty folder, and no longer leaks up to the tab bar
- Dropped the `autoFocus` guide + `requestTVFocus` re-anchor (unreliable on Fabric/tvOS after first use; caused an enter-huge-then-settle jump)
- Filters presented as a root route so the tab bar can't steal focus; Down focus trapped in the panel during loading

## Library
- Per-library filter scope and a year filter; shuffle plays the full filtered set in a fresh looping order
- Favorite hearts paint from the authoritative favorites set
- Folder revisits restore instantly from cache instead of showing a spinner
- Pagination falls back to page size when the server omits `TotalRecordCount`
- Faint oversized library-name watermark in the folder header

## Release
- CHANGELOG `[1.7.0]` filled in (Added / Changed / Fixed)
- Version already at 1.7.0 (package.json, app.json incl. `ios.version`)
- Note: `ios.buildNumber` is still `"1"` — correct for a first 1.7.0 upload; bump to `"2"` if a 1.7.0 build was already sent to App Store Connect

## Verification
- tsc, eslint, and jest (565 passing) green
- Focus fix confirmed on-device (library switch + Up-to-Filters); a full pre-submission pass on the release build is still recommended