### PR TITLE
fix(settings): restore tvOS focus into the server and quality cards

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Tomo TV",
     "slug": "tomotv",
     "description": "Stream any video from your Jellyfin server. Automatic transcoding handles incompatible formats so you can just hit play and watch.",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "orientation": "default",
     "icon": "./assets/brand/tomo-tv.png",
     "scheme": "tomotv",
@@ -13,7 +13,7 @@
       "supportsTablet": true,
       "appleTeamId": "64QR53M8C9",
       "bundleIdentifier": "dev.keiver.tomotv",
-      "buildNumber": "11",
+      "buildNumber": "2",
       "config": {
         "usesNonExemptEncryption": false
       },

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -184,8 +184,8 @@ export default function SettingsScreen() {
               {/* The preset list is taller than the space left under the server card, so it
                   scrolls inside the section instead of running off the bottom of the screen.
                   The wrapper carries the section's radius + overflow: hidden (clipping rows to
-                  the card corners) and hosts the inset-shadow overlay, which must sit above the
-                  scrolling rows rather than scroll with them. */}
+                  the card corners) and its inset shadow, which stays pinned to the card edges
+                  while the transparent rows scroll over it. */}
               <View style={styles.section}>
                 <ScrollView ref={qualityListRef} style={styles.sectionScrollable} showsVerticalScrollIndicator={false} nestedScrollEnabled focusable={false}>
                   {QUALITY_PRESETS.map((preset, index) => (
@@ -215,7 +215,6 @@ export default function SettingsScreen() {
                     </Pressable>
                   ))}
                 </ScrollView>
-                <View style={styles.sectionInnerShadow} />
               </View>
             </>
           )}

--- a/components/settings/ConnectedSection.tsx
+++ b/components/settings/ConnectedSection.tsx
@@ -34,7 +34,6 @@ export function ConnectedSection({ serverName, serverUrl, userName, onSignOut }:
       <View style={[settingsStyles.listItem, settingsStyles.listItemLast]}>
         <FocusableButton title="Sign Out" variant="destructive" onPress={onSignOut} style={signOutButtonStyle} />
       </View>
-      <View style={settingsStyles.sectionInnerShadow} />
     </View>
   );
 }
@@ -49,9 +48,9 @@ const styles = StyleSheet.create({
     borderRadius: 0,
     padding: 10,
     paddingLeft: "9%",
-    marginTop: -30,
+    marginTop: Platform.isTV ? -45 : -30,
     paddingTop: "8%",
-    paddingBottom: "7%",
+    paddingBottom: Platform.isTV ? "6%" : "7%",
     marginLeft: "-9%",
     marginRight: "-9%",
   },

--- a/components/settings/NotConnectedSection.tsx
+++ b/components/settings/NotConnectedSection.tsx
@@ -7,7 +7,7 @@ import { describeSubnet } from "@/services/networkDiscovery";
 import type { UseNetworkScanReturn } from "@/hooks/useNetworkScan";
 import { SavedServer } from "@/types/jellyfin";
 import React, { useState } from "react";
-import { Text, TextInput, View } from "react-native";
+import { Platform, Text, TextInput, View } from "react-native";
 
 interface NotConnectedSectionProps {
   serverUrl: string;
@@ -177,7 +177,6 @@ export function NotConnectedSection({
           </View>
         </View>
       )}
-      <View style={styles.sectionInnerShadow} />
     </View>
   );
 }

--- a/components/settings/QuickConnectSection.tsx
+++ b/components/settings/QuickConnectSection.tsx
@@ -93,7 +93,6 @@ export function QuickConnectSection({ code, status, error, onCancel, onSwitchToP
         ) : (
           <View style={cardStyle}>{cardContent}</View>
         )}
-        <View style={settingsStyles.sectionInnerShadow} />
       </View>
 
       <View style={settingsStyles.buttonGroup}>

--- a/components/settings/UsernamePasswordSection.tsx
+++ b/components/settings/UsernamePasswordSection.tsx
@@ -34,7 +34,13 @@ export function UsernamePasswordSection({
 }: UsernamePasswordSectionProps) {
   return (
     <>
-      <View style={settingsStyles.section}>
+      <View
+        style={[
+          settingsStyles.section,
+          {
+            padding: 30,
+          },
+        ]}>
         {serverName ? (
           <View style={[settingsStyles.listItem, settingsStyles.listItemFirst]}>
             <View style={styles.serverBadge}>

--- a/components/settings/styles.ts
+++ b/components/settings/styles.ts
@@ -14,7 +14,7 @@ export const settingsStyles = StyleSheet.create({
   scrollContent: {
     // Phone: 8 matches the Search/Library title offset (the ScrollView's automatic
     // inset adjustment supplies the safe-area part).
-    paddingTop: Platform.isTV ? 20 : 8,
+    paddingTop: Platform.isTV ? 4 : 8,
     paddingBottom: Platform.isTV ? 60 : 40,
     alignItems: "center",
   },
@@ -25,7 +25,7 @@ export const settingsStyles = StyleSheet.create({
   },
   sectionHeader: {
     paddingHorizontal: Platform.isTV ? 16 : 16,
-    paddingTop: Platform.isTV ? 32 : 10,
+    paddingTop: Platform.isTV ? 16 : 10,
     paddingBottom: Platform.isTV ? 12 : 8,
   },
   // Phone tab title (28pt, matching Search/Library); TV has no screen titles.
@@ -48,13 +48,21 @@ export const settingsStyles = StyleSheet.create({
     letterSpacing: -0.08,
   },
   // Section (Grouped List)
+  // The sunken look lives on the section itself: an inset boxShadow paints above
+  // the background but below children, and the rows are transparent (see
+  // listItem) so it shows through. No overlay view — anything rendered above a
+  // focusable occludes it on tvOS and the focus engine refuses to enter.
+  // Top and bottom lips carry matched, restrained shadows; the tight rim keeps
+  // the edge defined instead of reading as a faded vignette.
   section: {
     backgroundColor: "#2C2C2E",
     borderRadius: Platform.isTV ? 32 : 32,
     overflow: "hidden",
     // Phone: 12 + the next header's 10 top padding = 22 between sections.
     marginBottom: Platform.isTV ? 32 : 12,
-    padding: Platform.isTV ? 15 : 10,
+    boxShadow: Platform.isTV
+      ? "inset 0 6px 8px rgba(0,0,0,0.35), inset 0 -8px 7px rgba(0,0,0,0.35), inset 0 0 3px rgba(0,0,0,0.5)"
+      : "inset 0 4px 5px rgba(0,0,0,0.35), inset 0 -4px 4px rgba(0,0,0,0.35), inset 0 0 2px rgba(0,0,0,0.5)",
   },
   // Video Quality is the one section long enough to run past the bottom of the
   // screen, so it caps its height and scrolls internally. A row is ~120 (TV) /
@@ -65,14 +73,11 @@ export const settingsStyles = StyleSheet.create({
   sectionScrollable: {
     maxHeight: Platform.isTV ? 370 : 330,
   },
-  // Inset shadows for the sunken section cards (video quality, connected server,
-  // server list), on a transparent overlay rather than the container: the rows
-  // paint an opaque background edge to edge, so a boxShadow on the container
-  // itself would sit underneath them and never show. Render it as the section's
-  // last child so it draws above the rows.
-  // Radius matches the section so the shadow follows the card corners. Top lip
-  // casts the dominant shadow, bottom stays subtler, and the tight rim keeps the
-  // edge defined instead of reading as a faded vignette.
+  // Overlay variant of the section's inset shadow, for cards whose content
+  // paints an opaque background above the container (the sunken text input's
+  // field). Phone-only surfaces ONLY: on tvOS an overlay above a focusable
+  // occludes it and kills focus — the section cards carry the shadow on the
+  // container itself instead (see section above).
   sectionInnerShadow: {
     position: "absolute",
     top: 0,
@@ -95,10 +100,15 @@ export const settingsStyles = StyleSheet.create({
     marginVertical: Platform.isTV ? 12 : 8,
   },
   // List Items
+  // Transparent rows: the section card paints the surface, so the inset-shadow
+  // overlay can render UNDER the rows and still show through. It must never sit
+  // above them — on tvOS any view covering a focusable occludes it and the
+  // focus engine refuses to enter (react-native-tvos reports
+  // isUserInteractionEnabled YES for every plain view; pointerEvents can't opt out).
   listItem: {
-    backgroundColor: "#2C2C2E",
+    backgroundColor: "transparent",
     paddingHorizontal: Platform.isTV ? 28 : 16,
-    paddingVertical: Platform.isTV ? 24 : 16,
+    paddingVertical: 29,
     marginHorizontal: Platform.isTV ? 0 : 0,
   },
   listItemFirst: {

--- a/memories/CLAUDE-lessons-learned.md
+++ b/memories/CLAUDE-lessons-learned.md
@@ -20,31 +20,9 @@ This document captures important lessons from debugging sessions, bugs, and issu
 
 ---
 
-## Decorative Overlays Occlude tvOS Focus (August 2026)
+## Note: Views Above Focusables Kill tvOS Focus (August 2026)
 
-### Problem
-
-After the 2.0.1 settings polish (PR #61), tvOS focus could no longer enter the Jellyfin Server sections: Down from the tab bar did nothing on the Settings tab (Sign Out unreachable when logged in) and on the logged-out connect list. iPhone taps on the same screens worked fine.
-
-### Root Cause
-
-PR #61 added a `sectionInnerShadow` inset-shadow overlay as the last child of each section card — absolutely positioned over the entire card, above the focusable rows, with `pointerEvents: "none"` in its style. UIFocusDebugger (`checkFocusabilityForItem:` via lldb attached to the sim process) reported every row "visually occluded by" that overlay view. react-native-tvos's Fabric `RCTViewComponentView` overrides `isUserInteractionEnabled` to return YES for every plain view (only TV focus guides consult `isTVSelectable`), so neither style nor prop `pointerEvents="none"` can make an overlay non-interactive for UIKit's focus occlusion pass. Touches were unaffected because Fabric's own `hitTest:` reads `_props->pointerEvents` directly and returns nil — which is why the phone worked and TV focus silently died.
-
-### Solution
-
-Deleted the section overlays entirely and inverted the paint order: `listItem` backgrounds became transparent and the `section` card itself carries the inset `boxShadow` (an inset shadow paints above the view's background but below its children, so it shows through the transparent rows). Nothing renders above the focusables on either platform, the sunken look survives on both, and the PR's 15/10pt section padding (which existed to frame the overlay) was removed. `sectionInnerShadow` remains only for `sunken-text-input`, a phone-only surface with an opaque field. Verified via UIFocusDebugger ("This item should be focusable") plus live focus movement between rows on the tvOS sim.
-
-### Key Takeaways
-
-1. **On tvOS, never absolutely position ANY view above focusable items** — not even "decorative, pointerEvents:none" ones. react-native-tvos hard-codes `isUserInteractionEnabled = YES` on plain Fabric views, so the focus engine's occlusion check treats every covering sibling as a blocker. `pointerEvents` only opts views out of touch, not focus occlusion.
-2. **"Works on iPhone, dead on tvOS" splits at touch-vs-focus pipelines.** Touch = Fabric `hitTest` (honors `pointerEvents`); focus eligibility = UIKit occlusion (honors only `isUserInteractionEnabled`). Diagnose the focus side with facts, not the touch side's behavior.
-3. **UIFocusDebugger via lldb is the ground truth for tvOS focus.** `lldb -b -p <sim-app-pid>` then `expr -l objc -O -- [NSClassFromString(@"UIFocusDebugger") checkFocusabilityForItem:(id)0x…]` names the exact occluding view; `recursiveDescription` finds the pointers. Minutes of this beat hours of code-plausibility theorizing.
-4. **Simulator input plumbing is its own failure mode:** synthetic CGEvent keystrokes only reach a sim after I/O ▸ Input ▸ "Send Keyboard Input to Device" is enabled for that window, and even then may not drive the tvOS remote. Don't infer "focus is stuck" from an unresponsive sim until input delivery is proven (e.g. tab-bar Right also failing).
-
-### Files Affected
-
-- `components/settings/styles.ts` (transparent `listItem`, inset `boxShadow` on `section`, section padding removed)
-- `components/settings/ConnectedSection.tsx`, `components/settings/NotConnectedSection.tsx`, `components/settings/QuickConnectSection.tsx`, `app/(tabs)/settings.tsx` (overlay views deleted)
+Never absolutely position any view above focusable items on tvOS, even decorative ones: react-native-tvos hard-codes `isUserInteractionEnabled = YES` on plain Fabric views, so the focus engine treats every covering sibling as occlusion and `pointerEvents: "none"` cannot opt out (it only affects touch, which is why iPhone masks the bug). For sunken-card looks, put the inset `boxShadow` on the container and make row backgrounds transparent. Diagnose with lldb on the sim app: `[UIFocusDebugger checkFocusabilityForItem:]` names the occluder.
 
 ---
 

--- a/memories/CLAUDE-lessons-learned.md
+++ b/memories/CLAUDE-lessons-learned.md
@@ -20,6 +20,34 @@ This document captures important lessons from debugging sessions, bugs, and issu
 
 ---
 
+## Decorative Overlays Occlude tvOS Focus (August 2026)
+
+### Problem
+
+After the 2.0.1 settings polish (PR #61), tvOS focus could no longer enter the Jellyfin Server sections: Down from the tab bar did nothing on the Settings tab (Sign Out unreachable when logged in) and on the logged-out connect list. iPhone taps on the same screens worked fine.
+
+### Root Cause
+
+PR #61 added a `sectionInnerShadow` inset-shadow overlay as the last child of each section card — absolutely positioned over the entire card, above the focusable rows, with `pointerEvents: "none"` in its style. UIFocusDebugger (`checkFocusabilityForItem:` via lldb attached to the sim process) reported every row "visually occluded by" that overlay view. react-native-tvos's Fabric `RCTViewComponentView` overrides `isUserInteractionEnabled` to return YES for every plain view (only TV focus guides consult `isTVSelectable`), so neither style nor prop `pointerEvents="none"` can make an overlay non-interactive for UIKit's focus occlusion pass. Touches were unaffected because Fabric's own `hitTest:` reads `_props->pointerEvents` directly and returns nil — which is why the phone worked and TV focus silently died.
+
+### Solution
+
+Deleted the section overlays entirely and inverted the paint order: `listItem` backgrounds became transparent and the `section` card itself carries the inset `boxShadow` (an inset shadow paints above the view's background but below its children, so it shows through the transparent rows). Nothing renders above the focusables on either platform, the sunken look survives on both, and the PR's 15/10pt section padding (which existed to frame the overlay) was removed. `sectionInnerShadow` remains only for `sunken-text-input`, a phone-only surface with an opaque field. Verified via UIFocusDebugger ("This item should be focusable") plus live focus movement between rows on the tvOS sim.
+
+### Key Takeaways
+
+1. **On tvOS, never absolutely position ANY view above focusable items** — not even "decorative, pointerEvents:none" ones. react-native-tvos hard-codes `isUserInteractionEnabled = YES` on plain Fabric views, so the focus engine's occlusion check treats every covering sibling as a blocker. `pointerEvents` only opts views out of touch, not focus occlusion.
+2. **"Works on iPhone, dead on tvOS" splits at touch-vs-focus pipelines.** Touch = Fabric `hitTest` (honors `pointerEvents`); focus eligibility = UIKit occlusion (honors only `isUserInteractionEnabled`). Diagnose the focus side with facts, not the touch side's behavior.
+3. **UIFocusDebugger via lldb is the ground truth for tvOS focus.** `lldb -b -p <sim-app-pid>` then `expr -l objc -O -- [NSClassFromString(@"UIFocusDebugger") checkFocusabilityForItem:(id)0x…]` names the exact occluding view; `recursiveDescription` finds the pointers. Minutes of this beat hours of code-plausibility theorizing.
+4. **Simulator input plumbing is its own failure mode:** synthetic CGEvent keystrokes only reach a sim after I/O ▸ Input ▸ "Send Keyboard Input to Device" is enabled for that window, and even then may not drive the tvOS remote. Don't infer "focus is stuck" from an unresponsive sim until input delivery is proven (e.g. tab-bar Right also failing).
+
+### Files Affected
+
+- `components/settings/styles.ts` (transparent `listItem`, inset `boxShadow` on `section`, section padding removed)
+- `components/settings/ConnectedSection.tsx`, `components/settings/NotConnectedSection.tsx`, `components/settings/QuickConnectSection.tsx`, `app/(tabs)/settings.tsx` (overlay views deleted)
+
+---
+
 ## Playback Reporter Write Races Corrupt Server Resume State (August 2026)
 
 ### Problem

--- a/package-lock.json
+++ b/package-lock.json
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/@expo-google-fonts/material-symbols": {
-      "version": "0.4.42",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.42.tgz",
-      "integrity": "sha512-KZmHZRcthJ3KFZZlpzHjopA9guZgWR9fb3uVZlTR0BNlvG2pw1bnYBCpkze2PB0vRllwGhAM7lWXsfmcWCbXYg==",
+      "version": "0.4.43",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.43.tgz",
+      "integrity": "sha512-jJzgVcbkJnl48X5iBFNaL5CQHwoBElJapl8unc2Ri8DnyuBR+gRiuAD4gu3ESZjjo3sknIoYIwloOsWzKbLknQ==",
       "license": "MIT AND Apache-2.0"
     },
     "node_modules/@expo/code-signing-certificates": {
@@ -16748,9 +16748,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
-      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Problem

After the 2.0.1 settings polish, tvOS focus could not enter the Jellyfin Server sections: Down from the tab bar did nothing and the Sign Out button was unreachable when logged in. iPhone taps worked fine.

## Root cause

The inset-shadow overlays (`sectionInnerShadow`) covered each section card above its focusable rows. UIFocusDebugger reports the rows as "visually occluded" by the overlay: react-native-tvos returns YES from `isUserInteractionEnabled` for every plain Fabric view, so `pointerEvents: none` cannot opt an overlay out of focus occlusion. Touches were unaffected because Fabric `hitTest` reads `_props->pointerEvents` directly, which is why the phone masked the bug.

## Fix

- Sunken look moves onto the section itself: inset `boxShadow` on the card, transparent `listItem` backgrounds so it shows through (an inset shadow paints above the background but below children)
- Overlay views deleted from ConnectedSection, NotConnectedSection, QuickConnectSection, and the Video Quality list; nothing renders above a focusable anymore
- The overlay's 15/10pt framing padding removed, top lip softened
- `sectionInnerShadow` remains only for the phone-only sunken text input
- Settings card spacing polish

## Verified

- tvOS sim: UIFocusDebugger reports rows focusable, focus enters from the tab bar and moves between rows
- iPhone sim: connected card and quality list render the sunken look, Sign Out tap works
- 76 tests pass across `components` and `app`