### PR TITLE
fix(playback): key the bitrate memory to its network, add re-measure triggers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,15 +142,20 @@ Workflow: Edit in `native/ios/MultiAudioResourceLoader/` -> `npm run prebuild:tv
 
 ### Comments: 1-2 lines, present tense
 
-Say the constraint or the non-obvious "why", then stop. Cut anything a reader can get from the code itself.
+Say the constraint or the non-obvious "why", then stop. Cut anything a reader can get from the code itself. Hard ceilings: a docblock is 3 lines, an inline block is 2, and comments stay under 15% of the lines a diff adds. Over the ceiling, delete before rewriting.
 
 Never write:
 
 - **Temporal framing** -- "now", "used to", "no longer", "previously", "the old X", "this replaced Y". There is no "then" for a future reader. When behaviour changes, DELETE the comment describing the old behaviour instead of narrating the change.
 - **Justification blocks** defending a choice or explaining what could not be done. That belongs in the commit message.
 - **Essays in data files.** A `comment` field in a JSON manifest or fixture is still a comment and takes the same limit.
+- **Restated call graphs.** "Six readers depend on this memory and none probe for themselves", "also runs on audio switch, seek recovery and retries". A caller list is wrong the day someone adds a caller, and a reviewer who believes it stops grepping.
 
 This is not style. Long comments go stale, and stale comments get acted on: a header claiming a library could not be linked survived after it was linked, and a probe comment asserting a code path that no longer existed produced a false regression report.
+
+### Reviewing: comments are what is under review, never the evidence
+
+Open the call path before repeating any claim a comment makes, including comments inside the diff being reviewed and claims in its commit message. Volume is the trap: a dense comment layer reads as understanding and displaces the reading of the code. On `fix/link-measurement-triggers` a 36%-comment diff produced a review that graded prose, forwarded the code's own comment about which paths re-enter a function as a finding, and asserted an OS fact from memory. Every finding names a file:line that was actually opened, or it does not ship.
 
 ## Known Issues
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -7,7 +7,7 @@ import { ListRow } from "@/components/settings/ListRow";
 import { ServerConnectFlow } from "@/components/settings/ServerConnectFlow";
 import { QUALITY_SUBTITLE_LINE_HEIGHT, QUALITY_TITLE_LINE_HEIGHT, settingsStyles as styles } from "@/components/settings/styles";
 import { linkCarriesPreset, ORIGINAL_INDEX, pickStartupIndex } from "@/services/adaptiveQuality";
-import { measureServerBitrate, rememberedBitrateStatus } from "@/services/jellyfin/bitrateTest";
+import { measureIfIdle, rememberedBitrateStatus } from "@/services/jellyfin/bitrateTest";
 import { QUALITY_PRESETS as PLAYER_PRESETS } from "@/services/jellyfin/constants";
 import { DEMO_USERNAME, getStoredUserName, isDemoMode } from "@/services/jellyfinApi";
 import { logger } from "@/utils/logger";
@@ -88,12 +88,8 @@ export default function SettingsScreen() {
     }
   };
 
-  // Measured link to the connected server, feeding the quality heading and the
-  // rows' capacity marks. The remembered value shows instantly; anything the
-  // triggers would re-measure is re-measured here too, since settings is an idle
-  // moment. On FOCUS, not on mount: the tab stays mounted across a server switch
-  // and across every measurement that lands while the user is elsewhere, so a
-  // mount-keyed read would never run a second time.
+  // Measured link to the connected server, feeding the quality heading and the rows'
+  // capacity marks. On focus, not on mount: the tab stays mounted across a server switch.
   const [measuredBps, setMeasuredBps] = useState<number | null>(null);
   const [measuring, setMeasuring] = useState(false);
 
@@ -112,7 +108,7 @@ export default function SettingsScreen() {
           return;
         }
         setMeasuring(true);
-        const bps = await measureServerBitrate();
+        const bps = await measureIfIdle();
         if (cancelled) return;
         if (bps != null) setMeasuredBps(bps);
         setMeasuring(false);

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -14,7 +14,7 @@ import { logger } from "@/utils/logger";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect, useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { ActivityIndicator, Alert, Keyboard, Platform, ScrollView, StyleSheet, Text, View } from "react-native";
 
 const STORAGE_KEYS = {
@@ -54,7 +54,7 @@ export default function SettingsScreen() {
   // highlighted row matches what playback actually uses before a choice is saved
   const [videoQuality, setVideoQuality] = useState(5);
 
-  const loadCurrentState = async () => {
+  const loadCurrentState = async (): Promise<ScreenState> => {
     try {
       const [savedUrl, savedKey, savedUserId, savedQuality, savedUserName, demoActive] = await Promise.all([
         SecureStore.getItemAsync(STORAGE_KEYS.SERVER_URL),
@@ -77,55 +77,52 @@ export default function SettingsScreen() {
         // DEMO_USERNAME account, so the flag maps to that name.
         setConnectedUserName(demoActive ? DEMO_USERNAME : savedUserName || "");
         setScreenState("CONNECTED");
-      } else {
-        setScreenState("NOT_CONNECTED");
+        return "CONNECTED";
       }
+      setScreenState("NOT_CONNECTED");
+      return "NOT_CONNECTED";
     } catch (error) {
       logger.error("Error loading settings state", error);
       setScreenState("NOT_CONNECTED");
+      return "NOT_CONNECTED";
     }
   };
 
+  // Measured link to the connected server, feeding the quality heading and the
+  // rows' capacity marks. The remembered value shows instantly; anything the
+  // triggers would re-measure is re-measured here too, since settings is an idle
+  // moment. On FOCUS, not on mount: the tab stays mounted across a server switch
+  // and across every measurement that lands while the user is elsewhere, so a
+  // mount-keyed read would never run a second time.
+  const [measuredBps, setMeasuredBps] = useState<number | null>(null);
+  const [measuring, setMeasuring] = useState(false);
+
   useFocusEffect(
     useCallback(() => {
-      loadCurrentState();
+      let cancelled = false;
+      void (async () => {
+        const state = await loadCurrentState();
+        if (cancelled || state !== "CONNECTED") return;
+        const status = await rememberedBitrateStatus();
+        if (cancelled) return;
+        // Replaces the previous server's reading outright: null until measured.
+        setMeasuredBps(status?.bps ?? null);
+        if (status?.fresh) {
+          setMeasuring(false);
+          return;
+        }
+        setMeasuring(true);
+        const bps = await measureServerBitrate();
+        if (cancelled) return;
+        if (bps != null) setMeasuredBps(bps);
+        setMeasuring(false);
+      })();
       return () => {
+        cancelled = true;
         Keyboard.dismiss();
       };
     }, []),
   );
-
-  // Measured link to the connected server, feeding LinkSpeedRow and the rows'
-  // capacity marks. The remembered value shows instantly; a stale memory
-  // re-measures — settings is an idle moment, the same clean-reading window
-  // as the launch warm-up, and the result feeds the same per-server memory
-  // playback reads. Keyed on the server URL too: a switch never flips
-  // screenState (the tab stays CONNECTED and mounted), and the new server's
-  // link must replace the old reading rather than inherit it.
-  const [measuredBps, setMeasuredBps] = useState<number | null>(null);
-  const [measuring, setMeasuring] = useState(false);
-  useEffect(() => {
-    if (screenState !== "CONNECTED") return;
-    let cancelled = false;
-    void (async () => {
-      const status = await rememberedBitrateStatus();
-      if (cancelled) return;
-      // Replaces the previous server's reading outright: null until measured.
-      setMeasuredBps(status?.bps ?? null);
-      if (status?.fresh) {
-        setMeasuring(false);
-        return;
-      }
-      setMeasuring(true);
-      const bps = await measureServerBitrate();
-      if (cancelled) return;
-      if (bps != null) setMeasuredBps(bps);
-      setMeasuring(false);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [screenState, connectedServerUrl]);
 
   // The Auto row states the decision the player will make, computed by the
   // player's own startup pick — the menu cannot contradict the session.

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -80,20 +80,16 @@ export default function RootLayout() {
     warmBitrateMemory();
   }, []);
 
-  // Foregrounding is the one moment the link may be a different link entirely (a
-  // network change while backgrounded), and useAppStateRefresh holds it while
-  // playback owns the link, so a Top Shelf launch straight into a video never probes.
+  // Foregrounding is when the device may have changed networks.
   const warmOnForeground = useCallback(() => warmBitrateMemory(), []);
   useAppStateRefresh(warmOnForeground, "BitrateWarmup");
 
-  // Browsing keeps the reading inside its refresh window, so playback never opens
-  // on cold memory. Skipped on the playback routes and on the panel that precedes
-  // them: a probe there would race the stream it is meant to size.
+  // Browsing keeps the reading inside its refresh window. Skipped on the playback
+  // routes and the panel before them: a probe there races the stream it sizes.
   const navigationRef = useNavigationContainerRef();
   useEffect(() => {
     return navigationRef.addListener("state", () => {
-      // Cast because the app declares no ReactNavigation.RootParamList, which
-      // collapses getCurrentRoute's return type to `never`.
+      // Cast: no ReactNavigation.RootParamList is declared, so the return type is `never`.
       const route = (navigationRef.getCurrentRoute() as { name?: string } | undefined)?.name;
       if (route === "player" || route === "audio-player" || route === "video-info") return;
       nudgeBitrateMemory();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,12 @@
 import * as Linking from "expo-linking";
-import { DarkTheme, Stack, ThemeProvider } from "expo-router";
+import { DarkTheme, Stack, ThemeProvider, useNavigationContainerRef } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { LogBox, Platform } from "react-native";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import "react-native-reanimated";
 
 import { preloadAmbientBackgrounds } from "@/components/ambient-background";
-import { warmBitrateMemory } from "@/services/jellyfin/bitrateTest";
+import { nudgeBitrateMemory, warmBitrateMemory } from "@/services/jellyfin/bitrateTest";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { MacKeyCommands } from "@/components/mac-key-commands";
 import { PlayerHost } from "@/components/player-host";
@@ -16,6 +16,7 @@ import { LoadingProvider } from "@/contexts/LoadingContext";
 import { LibraryProvider } from "@/contexts/LibraryContext";
 import { LibraryFiltersProvider } from "@/contexts/LibraryFiltersContext";
 import { PlayerSessionProvider } from "@/contexts/PlayerSessionContext";
+import { useAppStateRefresh } from "@/hooks/useAppStateRefresh";
 import { PlayQueueProvider } from "@/contexts/PlayQueueContext";
 import { registerMultiAudioPlugin } from "@/services/multiAudioLoader";
 import { logger } from "@/utils/logger";
@@ -78,6 +79,26 @@ export default function RootLayout() {
     // instead of ever probing on the session-start path.
     warmBitrateMemory();
   }, []);
+
+  // Foregrounding is the one moment the link may be a different link entirely (a
+  // network change while backgrounded), and useAppStateRefresh holds it while
+  // playback owns the link, so a Top Shelf launch straight into a video never probes.
+  const warmOnForeground = useCallback(() => warmBitrateMemory(), []);
+  useAppStateRefresh(warmOnForeground, "BitrateWarmup");
+
+  // Browsing keeps the reading inside its refresh window, so playback never opens
+  // on cold memory. Skipped on the playback routes and on the panel that precedes
+  // them: a probe there would race the stream it is meant to size.
+  const navigationRef = useNavigationContainerRef();
+  useEffect(() => {
+    return navigationRef.addListener("state", () => {
+      // Cast because the app declares no ReactNavigation.RootParamList, which
+      // collapses getCurrentRoute's return type to `never`.
+      const route = (navigationRef.getCurrentRoute() as { name?: string } | undefined)?.name;
+      if (route === "player" || route === "audio-player" || route === "video-info") return;
+      nudgeBitrateMemory();
+    });
+  }, [navigationRef]);
 
   // Deep links are sticky for the life of the PROCESS, not the JS context.
   // LinkingAppDelegateSubscriber writes every incoming URL into

--- a/components/player-host.tsx
+++ b/components/player-host.tsx
@@ -1,7 +1,7 @@
 import { DismissPan } from "@/components/dismiss-pan";
 import { ImageSubtitleOverlay } from "@/components/image-subtitle-overlay";
 import { usePlayerSessionHost, type HostMode, type PlayerHostBridge, type PlayerTvConfig } from "@/contexts/PlayerSessionContext";
-import { setForegroundRefreshHold } from "@/hooks/useAppStateRefresh";
+import { setPlaybackHold } from "@/services/playbackHold";
 import { useVideoPlayback } from "@/hooks/useVideoPlayback";
 import { getPosterUrl, hasPoster } from "@/services/jellyfinApi";
 import { IS_MAC } from "@/utils/hostEnvironment";
@@ -289,12 +289,13 @@ export function PlayerHost() {
     });
   }, [publish, hostMode, session, state, showLoadingOverlay, sourceUri]);
 
-  // Suppress the foreground refresh storm for as long as a session lives — a
-  // Top Shelf launch foregrounds the app straight into playback, and the
-  // library/folder refetches would compete with stream startup. Held through a
-  // detached PiP window too: that is still playback (see useAppStateRefresh).
+  // Playback owns the link and the JS thread for as long as a session lives, so
+  // background work that competes with stream startup stands down (the foreground
+  // refresh storm, the link probe). Held through a detached PiP window too: that
+  // is still playback.
   useEffect(() => {
-    setForegroundRefreshHold(session !== null);
+    setPlaybackHold("video", session !== null);
+    return () => setPlaybackHold("video", false);
   }, [session]);
 
   // AirPlay / Now Playing metadata: react-native-video copies source.metadata into

--- a/components/player-host.tsx
+++ b/components/player-host.tsx
@@ -289,10 +289,8 @@ export function PlayerHost() {
     });
   }, [publish, hostMode, session, state, showLoadingOverlay, sourceUri]);
 
-  // Playback owns the link and the JS thread for as long as a session lives, so
-  // background work that competes with stream startup stands down (the foreground
-  // refresh storm, the link probe). Held through a detached PiP window too: that
-  // is still playback.
+  // Playback owns the link and the JS thread while a session lives, so competing
+  // background work stands down. Held through a detached PiP window too.
   useEffect(() => {
     setPlaybackHold("video", session !== null);
     return () => setPlaybackHold("video", false);

--- a/hooks/useAppStateRefresh.ts
+++ b/hooks/useAppStateRefresh.ts
@@ -1,23 +1,18 @@
 import { useEffect, useRef } from "react";
 import { AppState, AppStateStatus } from "react-native";
+import { isPlaybackHeld } from "@/services/playbackHold";
 import { logger } from "@/utils/logger";
-
-// While the player screen is mounted, foreground refreshes are skipped: a Top Shelf
-// launch (or returning to an in-progress video) foregrounds the app straight into
-// playback, and the refresh storm — library cache wipe + one refetch per mounted
-// folder screen — competes with stream startup for the JS thread and the network.
-// Nothing goes permanently stale: the rows and folder screens refetch on focus when
-// the user navigates back to them.
-let foregroundRefreshHeld = false;
-
-/** Set by the player while mounted; suppresses all useAppStateRefresh callbacks. */
-export function setForegroundRefreshHold(held: boolean): void {
-  foregroundRefreshHeld = held;
-}
 
 /**
  * Custom hook that triggers a callback when the app comes to the foreground
  * (transitions from background/inactive to active state)
+ *
+ * Skipped while playback holds the link: a Top Shelf launch (or returning to an
+ * in-progress video) foregrounds the app straight into playback, and the refresh
+ * storm — library cache wipe + one refetch per mounted folder screen — competes
+ * with stream startup for the JS thread and the network. Nothing goes permanently
+ * stale: the rows and folder screens refetch on focus when the user navigates
+ * back to them.
  *
  * @param onForeground - Callback to execute when app enters foreground
  * @param context - Context name for logging (e.g., "LibraryContext")
@@ -29,7 +24,7 @@ export function useAppStateRefresh(onForeground: () => void, context: string): v
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
       // Refresh when app comes to foreground (background/inactive -> active)
       if (appState.current.match(/inactive|background/) && nextAppState === "active") {
-        if (foregroundRefreshHeld) {
+        if (isPlaybackHeld()) {
           logger.debug("Foreground refresh skipped (playback active)", { context });
         } else {
           logger.info("App came to foreground, triggering refresh", {

--- a/hooks/useAppStateRefresh.ts
+++ b/hooks/useAppStateRefresh.ts
@@ -7,12 +7,8 @@ import { logger } from "@/utils/logger";
  * Custom hook that triggers a callback when the app comes to the foreground
  * (transitions from background/inactive to active state)
  *
- * Skipped while playback holds the link: a Top Shelf launch (or returning to an
- * in-progress video) foregrounds the app straight into playback, and the refresh
- * storm — library cache wipe + one refetch per mounted folder screen — competes
- * with stream startup for the JS thread and the network. Nothing goes permanently
- * stale: the rows and folder screens refetch on focus when the user navigates
- * back to them.
+ * Skipped while playback holds the link: the refresh storm (cache wipe plus one
+ * refetch per mounted folder screen) competes with stream startup. Screens refetch on focus.
  *
  * @param onForeground - Callback to execute when app enters foreground
  * @param context - Context name for logging (e.g., "LibraryContext")

--- a/services/__tests__/bitrateTest.test.ts
+++ b/services/__tests__/bitrateTest.test.ts
@@ -1,12 +1,4 @@
-/**
- * bitrateTest - the per-server link measurement the playback routing gate reads.
- *
- * The rules asserted here decide whether a session opens on a real number or on
- * nothing: a reading answers for the network it was taken on (at any age) and
- * for no other, concurrent triggers share one download, a dead refine stage
- * never costs the small stage's reading, and a failed probe is left alone for
- * its backoff instead of being retried by every trigger that fires.
- */
+/** bitrateTest - the per-server link measurement the playback routing gate reads. */
 
 jest.mock("@/utils/logger", () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
@@ -29,7 +21,7 @@ jest.mock("../jellyfin/session", () => ({
 import * as SecureStore from "expo-secure-store";
 import { describeSubnet, getLocalNetworkInfo } from "@/services/localNetworkIdentity";
 import { isPlaybackHeld } from "@/services/playbackHold";
-import { measureServerBitrate, nudgeBitrateMemory, rememberedBitrate, rememberedBitrateStatus, warmBitrateMemory } from "../jellyfin/bitrateTest";
+import { measureIfIdle, measureServerBitrate, nudgeBitrateMemory, rememberedBitrate, rememberedBitrateStatus, warmBitrateMemory } from "../jellyfin/bitrateTest";
 import { getAuthHeader, getConfig } from "../jellyfin/session";
 
 const SERVER = "http://10.0.0.5:8096";
@@ -151,6 +143,40 @@ describe("measurement", () => {
 
     await expect(measureServerBitrate()).resolves.toBeNull();
     expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it("holds a failed host for its backoff on a direct call, not only on a trigger", async () => {
+    // Settings and the Auto startup pick call in here directly; both used to
+    // re-probe a dead host on every visit, at 15s a time.
+    mockFetch.mockResolvedValue({ ok: false, arrayBuffer: jest.fn() });
+
+    await expect(measureServerBitrate()).resolves.toBeNull();
+    await expect(measureServerBitrate()).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    now += 61 * 1000;
+    await expect(measureServerBitrate()).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("never hands one server's probe to a caller on another server", async () => {
+    let releaseFirst: (value: unknown) => void = () => {};
+    mockFetch.mockImplementationOnce(() => new Promise((resolve) => (releaseFirst = resolve)));
+    const first = measureServerBitrate();
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // The switch lands while the first probe is still downloading.
+    mockGetConfig.mockResolvedValue({ server: "http://10.0.0.77:8096", apiKey: "key", userId: "u", deviceId: "d" });
+    mockFetch.mockResolvedValueOnce(stage(500_000, 1_000));
+
+    await expect(measureServerBitrate()).resolves.toBe(4_000_000);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0][0]).toContain("10.0.0.5");
+    expect(mockFetch.mock.calls[1][0]).toContain("10.0.0.77");
+
+    releaseFirst(stage(500_000, 2_000));
+    await first;
   });
 });
 
@@ -291,5 +317,18 @@ describe("triggers", () => {
     await jest.advanceTimersByTimeAsync(2_100);
     expect(mockGetItem).not.toHaveBeenCalled();
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("declines the settings measurement while playback owns the link", async () => {
+    mockHeld.mockReturnValue(true);
+
+    await expect(measureIfIdle()).resolves.toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("hands the new reading back to the settings surface", async () => {
+    mockFetch.mockResolvedValue(stage(500_000, 1_000));
+
+    await expect(measureIfIdle()).resolves.toBe(4_000_000);
   });
 });

--- a/services/__tests__/bitrateTest.test.ts
+++ b/services/__tests__/bitrateTest.test.ts
@@ -1,0 +1,295 @@
+/**
+ * bitrateTest - the per-server link measurement the playback routing gate reads.
+ *
+ * The rules asserted here decide whether a session opens on a real number or on
+ * nothing: a reading answers for the network it was taken on (at any age) and
+ * for no other, concurrent triggers share one download, a dead refine stage
+ * never costs the small stage's reading, and a failed probe is left alone for
+ * its backoff instead of being retried by every trigger that fires.
+ */
+
+jest.mock("@/utils/logger", () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/services/playbackHold", () => ({
+  isPlaybackHeld: jest.fn(),
+}));
+
+jest.mock("@/services/localNetworkIdentity", () => ({
+  getLocalNetworkInfo: jest.fn(),
+  describeSubnet: jest.fn(),
+}));
+
+jest.mock("../jellyfin/session", () => ({
+  getConfig: jest.fn(),
+  getAuthHeader: jest.fn(),
+}));
+
+import * as SecureStore from "expo-secure-store";
+import { describeSubnet, getLocalNetworkInfo } from "@/services/localNetworkIdentity";
+import { isPlaybackHeld } from "@/services/playbackHold";
+import { measureServerBitrate, nudgeBitrateMemory, rememberedBitrate, rememberedBitrateStatus, warmBitrateMemory } from "../jellyfin/bitrateTest";
+import { getAuthHeader, getConfig } from "../jellyfin/session";
+
+const SERVER = "http://10.0.0.5:8096";
+const HOST = "10.0.0.5:8096";
+const HOME = "10.0.0.0/24";
+const AWAY = "192.168.1.0/24";
+
+const mockGetConfig = getConfig as jest.Mock;
+const mockAuthHeader = getAuthHeader as jest.Mock;
+const mockNetworkInfo = getLocalNetworkInfo as jest.Mock;
+const mockDescribeSubnet = describeSubnet as jest.Mock;
+const mockHeld = isPlaybackHeld as jest.Mock;
+const mockGetItem = SecureStore.getItemAsync as jest.Mock;
+const mockSetItem = SecureStore.setItemAsync as jest.Mock;
+
+let now = 1_000_000_000;
+let mockFetch: jest.Mock;
+
+/** A probe response whose body read costs `elapsedMs` of wall clock. */
+function stage(bytes: number, elapsedMs: number) {
+  return {
+    ok: true,
+    arrayBuffer: async () => {
+      now += elapsedMs;
+      return new ArrayBuffer(bytes);
+    },
+  };
+}
+
+function storedMemory(entry: Record<string, unknown> | null): void {
+  mockGetItem.mockResolvedValue(entry ? JSON.stringify({ [HOST]: entry }) : null);
+}
+
+/** Report a different subnet from here on, past the module's cache window. */
+function moveToSubnet(subnet: string | null): void {
+  now += 11 * 1000;
+  mockNetworkInfo.mockResolvedValue(subnet ? { ip: "10.0.0.9", netmask: "255.255.255.0", interfaceName: "en0" } : null);
+  mockDescribeSubnet.mockReturnValue(subnet);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Date stays real so the probe's own timing arithmetic is driven by `now`.
+  jest.useFakeTimers({ doNotFake: ["Date"] });
+  // Past every window the module keeps between calls: the cached subnet, the
+  // failure backoff and the navigation floor all expire here.
+  now += 10 * 60 * 1000;
+  jest.spyOn(Date, "now").mockImplementation(() => now);
+
+  mockGetConfig.mockResolvedValue({ server: SERVER, apiKey: "key", userId: "u", deviceId: "d" });
+  mockAuthHeader.mockReturnValue('MediaBrowser Token="t"');
+  mockNetworkInfo.mockResolvedValue({ ip: "10.0.0.9", netmask: "255.255.255.0", interfaceName: "en0" });
+  mockDescribeSubnet.mockReturnValue(HOME);
+  mockHeld.mockReturnValue(false);
+  mockGetItem.mockResolvedValue(null);
+  mockSetItem.mockResolvedValue(undefined);
+  mockFetch = jest.fn();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("measurement", () => {
+  it("times the body and remembers the reading against the current subnet", async () => {
+    mockFetch.mockResolvedValueOnce(stage(500_000, 1_000));
+
+    // 500 KB in 1s = 4 Mbps. Too slow to read as timer noise, so one stage only.
+    await expect(measureServerBitrate()).resolves.toBe(4_000_000);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(mockSetItem.mock.calls[0][1])[HOST]).toEqual({ bps: 4_000_000, at: expect.any(Number), net: HOME });
+  });
+
+  it("issues the stage under an abort budget", async () => {
+    mockFetch.mockResolvedValueOnce(stage(500_000, 1_000));
+    await measureServerBitrate();
+
+    const signal = mockFetch.mock.calls[0][1].signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("refines with the big stage when the small one reads as timer noise", async () => {
+    mockFetch.mockResolvedValueOnce(stage(500_000, 100)).mockResolvedValueOnce(stage(2_000_000, 500));
+
+    await expect(measureServerBitrate()).resolves.toBe(32_000_000);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the small stage's reading when the refine stage dies", async () => {
+    mockFetch.mockResolvedValueOnce(stage(500_000, 100)).mockRejectedValueOnce(new Error("aborted"));
+
+    // 500 KB in 100ms = 40 Mbps. The refine measured the same link; losing it
+    // must not cost the reading that already landed.
+    await expect(measureServerBitrate()).resolves.toBe(40_000_000);
+    expect(JSON.parse(mockSetItem.mock.calls[0][1])[HOST].bps).toBe(40_000_000);
+  });
+
+  it("shares one download between concurrent callers", async () => {
+    mockFetch.mockResolvedValue(stage(500_000, 1_000));
+
+    const [a, b] = await Promise.all([measureServerBitrate(), measureServerBitrate()]);
+    expect(a).toBe(b);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the in-playback probe out of the shared probe and out of the memory", async () => {
+    mockFetch.mockResolvedValue(stage(500_000, 1_000));
+
+    await Promise.all([measureServerBitrate(), measureServerBitrate({ remember: false })]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockSetItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("remembers nothing when the server refuses the probe", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, arrayBuffer: jest.fn() });
+
+    await expect(measureServerBitrate()).resolves.toBeNull();
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("what a reading answers for", () => {
+  it("stands at any age on the subnet it was measured on", async () => {
+    storedMemory({ bps: 90_000_000, at: now - 3 * 24 * 60 * 60 * 1000, net: HOME });
+
+    // Three days old. The link is the same link, and the routing gate would
+    // rather have this than nothing.
+    await expect(rememberedBitrate()).resolves.toBe(90_000_000);
+  });
+
+  it("is void on a different subnet however fresh it is", async () => {
+    storedMemory({ bps: 90_000_000, at: now - 1_000, net: AWAY });
+
+    await expect(rememberedBitrate()).resolves.toBeNull();
+  });
+
+  it("falls back to the age backstop when the network cannot be identified", async () => {
+    moveToSubnet(null);
+    storedMemory({ bps: 90_000_000, at: now - 60 * 60 * 1000, net: HOME });
+    await expect(rememberedBitrate()).resolves.toBe(90_000_000);
+
+    storedMemory({ bps: 90_000_000, at: now - 25 * 60 * 60 * 1000, net: HOME });
+    await expect(rememberedBitrate()).resolves.toBeNull();
+  });
+
+  it("reads an entry written before subnets were recorded on age alone", async () => {
+    storedMemory({ bps: 90_000_000, at: now - 60 * 60 * 1000 });
+
+    await expect(rememberedBitrate()).resolves.toBe(90_000_000);
+  });
+
+  it("reports freshness to the settings surface off the refresh window", async () => {
+    storedMemory({ bps: 90_000_000, at: now - 60 * 1000, net: HOME });
+    await expect(rememberedBitrateStatus()).resolves.toEqual({ bps: 90_000_000, fresh: true });
+
+    storedMemory({ bps: 90_000_000, at: now - 20 * 60 * 1000, net: HOME });
+    await expect(rememberedBitrateStatus()).resolves.toEqual({ bps: 90_000_000, fresh: false });
+  });
+});
+
+describe("triggers", () => {
+  it("measures on a warm-up when nothing answers for this link", async () => {
+    mockFetch.mockResolvedValue(stage(500_000, 1_000));
+
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a fresh reading on this subnet alone", async () => {
+    storedMemory({ bps: 90_000_000, at: now - 60 * 1000, net: HOME });
+
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("re-measures a fresh reading taken on another subnet", async () => {
+    storedMemory({ bps: 90_000_000, at: now - 60 * 1000, net: AWAY });
+    mockFetch.mockResolvedValue(stage(500_000, 1_000));
+
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("stands down while playback owns the link", async () => {
+    mockHeld.mockReturnValue(true);
+
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("holds a failed host for its backoff instead of retrying on every trigger", async () => {
+    mockFetch.mockResolvedValue({ ok: false, arrayBuffer: jest.fn() });
+
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    now += 61 * 1000;
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays out of the launch window until the warm-up has run", async () => {
+    // The latch is once per process, so this needs a module that has never been
+    // warmed — which means re-wiring the mocks inside the isolated registry.
+    await jest.isolateModulesAsync(async () => {
+      const secureStore = require("expo-secure-store");
+      const identity = require("@/services/localNetworkIdentity");
+      const hold = require("@/services/playbackHold");
+      const session = require("../jellyfin/session");
+      secureStore.getItemAsync.mockResolvedValue(null);
+      identity.getLocalNetworkInfo.mockResolvedValue({ ip: "10.0.0.9", netmask: "255.255.255.0", interfaceName: "en0" });
+      identity.describeSubnet.mockReturnValue(HOME);
+      hold.isPlaybackHeld.mockReturnValue(false);
+      session.getConfig.mockResolvedValue({ server: SERVER, apiKey: "key", userId: "u", deviceId: "d" });
+
+      const fresh = require("../jellyfin/bitrateTest") as typeof import("../jellyfin/bitrateTest");
+      fresh.nudgeBitrateMemory();
+      await jest.advanceTimersByTimeAsync(2_100);
+      expect(secureStore.getItemAsync).not.toHaveBeenCalled();
+
+      fresh.warmBitrateMemory(0);
+      await jest.advanceTimersByTimeAsync(1);
+      expect(secureStore.getItemAsync).toHaveBeenCalled();
+    });
+  });
+
+  it("collapses a navigation burst into one attempt and floors the next one", async () => {
+    mockFetch.mockResolvedValue(stage(500_000, 1_000));
+    // The launch warm-up runs first and hands navigation the wheel.
+    warmBitrateMemory(0);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    mockFetch.mockClear();
+    now += 20 * 60 * 1000;
+    storedMemory(null);
+
+    nudgeBitrateMemory();
+    nudgeBitrateMemory();
+    nudgeBitrateMemory();
+    await jest.advanceTimersByTimeAsync(2_100);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Inside the floor: the next burst must not even reach the keychain.
+    mockGetItem.mockClear();
+    nudgeBitrateMemory();
+    await jest.advanceTimersByTimeAsync(2_100);
+    expect(mockGetItem).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/audioPlayerManager.ts
+++ b/services/audioPlayerManager.ts
@@ -29,6 +29,7 @@ import {
 } from "@/services/jellyfinApi";
 import * as audioQueuePlayer from "@/services/audioQueuePlayer";
 import type { JellyfinVideoItem } from "@/types/jellyfin";
+import { setPlaybackHold } from "@/services/playbackHold";
 import { logger } from "@/utils/logger";
 
 // Same resume policy as usePlaybackReporter: under 2s isn't worth resuming,
@@ -132,6 +133,7 @@ class AudioPlayerManager {
     this.sourceId = options.sourceId ?? null;
     this.pendingStartPosition = options.startPositionSeconds ?? 0;
     this.active = true;
+    setPlaybackHold("audio", true);
     this.uiVisible = true;
     this.playing = true;
     this.position = this.pendingStartPosition;
@@ -380,6 +382,7 @@ class AudioPlayerManager {
     this.unsubscribeNative?.();
     this.unsubscribeNative = null;
     this.active = false;
+    setPlaybackHold("audio", false);
     this.uiVisible = false;
     this.playing = false;
     this.position = 0;

--- a/services/jellyfin/bitrateTest.ts
+++ b/services/jellyfin/bitrateTest.ts
@@ -5,11 +5,18 @@
  * /Playback/BitrateTest endpoint (the jellyfin-web pattern: it downloads junk
  * bytes and times them). Staged like jellyfin-apiclient: a small probe first,
  * a larger one only when the link looks fast enough for the small one to be
- * timer-noise. Measured values are remembered per server host so the next
- * session's Auto pick starts informed before its first measurement lands.
+ * timer-noise.
+ *
+ * A reading belongs to a server AND to the network it was taken on, because
+ * those are the two things that make it wrong. Same subnet: it stands however
+ * old it is, since the routing gate in useVideoPlayback would rather have a
+ * stale LAN number than none. Different subnet: it is void however fresh it is.
+ * Age drives RE-MEASUREMENT, never discard.
  */
 
 import * as SecureStore from "expo-secure-store";
+import { describeSubnet, getLocalNetworkInfo } from "@/services/localNetworkIdentity";
+import { isPlaybackHeld } from "@/services/playbackHold";
 import { logger } from "@/utils/logger";
 import { API_TIMEOUTS, STORAGE_KEYS } from "./constants";
 import { fetchWithTimeout } from "./http";
@@ -19,15 +26,39 @@ import { getAuthHeader, getConfig } from "./session";
 const STAGE_SIZES = [500_000, 2_000_000];
 /** A first stage faster than this (seconds) is timer-noise; run the big stage. */
 const REFINE_THRESHOLD_SEC = 0.7;
-/** Remembered measurements older than this seed nothing. */
-const MEMORY_TTL_MS = 24 * 60 * 60 * 1000;
-/** App-start warm-up re-measures entries older than this: launch is an idle
- * moment, so the reading is clean, and it heals any drift. */
+/** Backstop for a reading with no network identity: age is all that is left to judge it by. */
+const UNKNOWN_NETWORK_TTL_MS = 24 * 60 * 60 * 1000;
+/** Past this a trigger re-measures. The reading keeps answering until the new one lands. */
 const REFRESH_AGE_MS = 15 * 60 * 1000;
+/** A host whose probe just failed is left alone this long, whatever fires next. */
+const FAILURE_BACKOFF_MS = 60 * 1000;
+/** Navigation bursts collapse into one attempt this far after the first of them. */
+const NUDGE_DEBOUNCE_MS = 2 * 1000;
+/** Floor between two navigation-driven attempts. */
+const NUDGE_THROTTLE_MS = 60 * 1000;
+/** The subnet read is cached this long, so a Wi-Fi handoff surfaces within it. */
+const NETWORK_ID_TTL_MS = 10 * 1000;
+
+interface BitrateEntry {
+  bps: number;
+  at: number;
+  /** Subnet the reading was taken on; absent on entries written before this existed. */
+  net?: string | null;
+}
 
 interface BitrateMemory {
-  [serverHost: string]: { bps: number; at: number };
+  [serverHost: string]: BitrateEntry;
 }
+
+/** Hosts whose last probe failed. Session-only: a relaunch retries clean. */
+const failedAt = new Map<string, number>();
+/** The one memory probe in flight, shared by every caller. */
+let inFlight: Promise<number | null> | null = null;
+let cachedNetworkId: { id: string | null; at: number } | null = null;
+let nudgeTimer: ReturnType<typeof setTimeout> | null = null;
+let lastNudgeAt = 0;
+/** The launch warm-up owns the first measurement; navigation only takes over after it. */
+let warmedOnce = false;
 
 function serverHost(server: string): string {
   try {
@@ -35,6 +66,31 @@ function serverHost(server: string): string {
   } catch {
     return server;
   }
+}
+
+/** The subnet the device is on, or null when it cannot be read. */
+async function currentNetworkId(): Promise<string | null> {
+  if (cachedNetworkId && Date.now() - cachedNetworkId.at < NETWORK_ID_TTL_MS) return cachedNetworkId.id;
+  let id: string | null = null;
+  try {
+    const info = await getLocalNetworkInfo();
+    id = info ? describeSubnet(info.ip, info.netmask) : null;
+  } catch (error) {
+    logger.debug("Network identity unavailable", { service: "BitrateTest", error: String(error) });
+  }
+  cachedNetworkId = { id, at: Date.now() };
+  return id;
+}
+
+/**
+ * Does this entry still answer for the link in front of us? Matching subnets say
+ * yes at any age. A different subnet is a different link. Unknown on either side
+ * leaves only the age backstop.
+ */
+function entryAnswersFor(entry: BitrateEntry | undefined, networkId: string | null): entry is BitrateEntry {
+  if (!entry) return false;
+  if (networkId != null && entry.net != null) return entry.net === networkId;
+  return Date.now() - entry.at < UNKNOWN_NETWORK_TTL_MS;
 }
 
 async function readMemory(): Promise<BitrateMemory> {
@@ -46,36 +102,39 @@ async function readMemory(): Promise<BitrateMemory> {
   }
 }
 
-/** Last measured bandwidth for the configured server, or null when unknown/stale. */
-export async function rememberedBitrate(): Promise<number | null> {
+/** The active server's entry alongside the network it has to answer for. */
+async function activeEntry(): Promise<{ host: string; entry: BitrateEntry | undefined; networkId: string | null } | null> {
   const config = await getConfig();
   if (!config.server) return null;
-  const memory = await readMemory();
-  const entry = memory[serverHost(config.server)];
-  if (!entry || Date.now() - entry.at > MEMORY_TTL_MS) return null;
-  return entry.bps;
+  const host = serverHost(config.server);
+  const [memory, networkId] = await Promise.all([readMemory(), currentNetworkId()]);
+  return { host, entry: memory[host], networkId };
+}
+
+/** Last measured bandwidth for the configured server, or null when nothing answers for this link. */
+export async function rememberedBitrate(): Promise<number | null> {
+  const active = await activeEntry();
+  if (!active) return null;
+  return entryAnswersFor(active.entry, active.networkId) ? active.entry.bps : null;
 }
 
 /**
- * Settings surface: the remembered value with a freshness verdict. `fresh`
- * uses the same REFRESH_AGE window as the launch warm-up, so the screen
- * re-measures exactly when the warm-up would have.
+ * Settings surface: the reading with a freshness verdict. `fresh` uses the same
+ * window as the triggers, so the screen re-measures exactly when they would.
  */
 export async function rememberedBitrateStatus(): Promise<{ bps: number; fresh: boolean } | null> {
-  const config = await getConfig();
-  if (!config.server) return null;
-  const entry = (await readMemory())[serverHost(config.server)];
-  if (!entry || Date.now() - entry.at > MEMORY_TTL_MS) return null;
-  return { bps: entry.bps, fresh: Date.now() - entry.at < REFRESH_AGE_MS };
+  const active = await activeEntry();
+  if (!active || !entryAnswersFor(active.entry, active.networkId)) return null;
+  return { bps: active.entry.bps, fresh: Date.now() - active.entry.at < REFRESH_AGE_MS };
 }
 
-async function remember(server: string, bps: number): Promise<void> {
+async function remember(server: string, bps: number, net: string | null): Promise<void> {
   try {
     const memory = await readMemory();
-    memory[serverHost(server)] = { bps, at: Date.now() };
+    memory[serverHost(server)] = { bps, at: Date.now(), net };
     await SecureStore.setItemAsync(STORAGE_KEYS.BITRATE_MEMORY, JSON.stringify(memory));
   } catch (error) {
-    logger.debug("Bitrate memory write failed", { service: "BitrateTest", error: String(error) });
+    logger.warn("Bitrate memory write failed", error, { service: "BitrateTest" });
   }
 }
 
@@ -91,48 +150,111 @@ async function timeStage(server: string, deviceId: string, apiKey: string | unde
   return (body.byteLength * 8) / seconds;
 }
 
+async function runProbe(shouldRemember: boolean): Promise<number | null> {
+  const config = await getConfig();
+  if (!config.server || !config.apiKey) return null;
+  const host = serverHost(config.server);
+  try {
+    const stageStart = Date.now();
+    let bps = await timeStage(config.server, config.deviceId, config.apiKey, STAGE_SIZES[0]);
+    if (bps == null) {
+      if (shouldRemember) failedAt.set(host, Date.now());
+      logger.warn("Bitrate test returned nothing usable", { service: "BitrateTest", host });
+      return null;
+    }
+    if ((Date.now() - stageStart) / 1000 < REFINE_THRESHOLD_SEC) {
+      // A refine that dies keeps the first stage: it measured the same link.
+      try {
+        const refined = await timeStage(config.server, config.deviceId, config.apiKey, STAGE_SIZES[1]);
+        if (refined != null) bps = refined;
+      } catch (error) {
+        logger.warn("Bitrate refine stage failed, keeping the small-stage reading", error, { service: "BitrateTest" });
+      }
+    }
+    failedAt.delete(host);
+    logger.info("Server bitrate measured", { service: "BitrateTest", mbps: Math.round(bps / 100_000) / 10, remembered: shouldRemember });
+    if (shouldRemember) await remember(config.server, bps, await currentNetworkId());
+    return bps;
+  } catch (error) {
+    // Only the memory probe feeds the backoff: the in-playback one shares the
+    // link with the player's segments, so its failures say nothing about the host.
+    if (shouldRemember) failedAt.set(host, Date.now());
+    logger.warn("Bitrate test failed", error, { service: "BitrateTest", host });
+    return null;
+  }
+}
+
 /**
- * Warm the per-server bitrate memory in the background: measure only when no
- * fresh memory exists, after a delay so app launch and the library's first
- * paint never compete with the probe download. A session that starts before
- * this lands measures inline instead (the Auto path in useVideoPlayback).
+ * Measure the link to the configured server, in bits/second.
+ *
+ * Concurrent callers share one download: a server switch arms both the warm-up
+ * and the settings read, and two probes on one link only measure each other.
+ *
+ * `remember: false` is the in-playback probe and stays outside that sharing. It
+ * runs while the player has the link, so its reading bounds the LEFTOVER
+ * bandwidth: safe for a step-up decision, poison as routing memory.
+ *
+ * Null on any failure — callers fall back to their ceiling, which is exactly the
+ * pre-adaptive behavior.
+ */
+export async function measureServerBitrate(options?: { remember?: boolean }): Promise<number | null> {
+  if (options?.remember === false) return runProbe(false);
+  if (!inFlight) {
+    inFlight = runProbe(true).finally(() => {
+      inFlight = null;
+    });
+  }
+  return inFlight;
+}
+
+/**
+ * Measure unless something already answers for this link: a reading on this
+ * network inside the refresh window, a failure still inside its backoff, or
+ * playback holding the link.
+ */
+async function warmIfStale(): Promise<void> {
+  if (isPlaybackHeld()) return;
+  // Every trigger re-reads the interface: a foreground or a switch is exactly
+  // when the device may have moved networks.
+  cachedNetworkId = null;
+  const config = await getConfig();
+  if (!config.server || !config.apiKey) return;
+  const host = serverHost(config.server);
+  const failed = failedAt.get(host);
+  if (failed != null && Date.now() - failed < FAILURE_BACKOFF_MS) return;
+  const active = await activeEntry();
+  if (active && entryAnswersFor(active.entry, active.networkId) && Date.now() - active.entry.at < REFRESH_AGE_MS) return;
+  await measureServerBitrate();
+}
+
+/**
+ * Warm the memory in the background: launch, sign-in, account switch, a URL the
+ * recovery ladder adopted, a foreground. The delay keeps the probe download off
+ * app launch and the library's first paint.
  */
 export function warmBitrateMemory(delayMs: number = 5_000): void {
   setTimeout(() => {
-    void (async () => {
-      const config = await getConfig();
-      if (!config.server) return;
-      const entry = (await readMemory())[serverHost(config.server)];
-      if (entry && Date.now() - entry.at < REFRESH_AGE_MS) return;
-      await measureServerBitrate();
-    })();
+    warmedOnce = true;
+    void warmIfStale();
   }, delayMs);
 }
 
 /**
- * Measure the link to the configured server, in bits/second. Remembers the
- * result per server unless `remember` is false — an in-playback probe shares
- * the link with the player's own segment downloads, so its reading bounds the
- * LEFTOVER bandwidth: safe for a step-up decision, poison as routing memory.
- * Null on any failure — callers fall back to their ceiling, which is exactly
- * the pre-adaptive behavior.
+ * Navigation-rate entry point. A burst collapses into one attempt and attempts
+ * are floored a minute apart, so browsing costs a keychain read rather than a
+ * download. What it protects is the routing gate in useVideoPlayback: that gate
+ * reads this memory and deliberately never probes for itself, so a session that
+ * starts on cold memory silently loses it.
  */
-export async function measureServerBitrate(options?: { remember?: boolean }): Promise<number | null> {
-  try {
-    const config = await getConfig();
-    if (!config.server || !config.apiKey) return null;
-    const stageStart = Date.now();
-    let bps = await timeStage(config.server, config.deviceId, config.apiKey, STAGE_SIZES[0]);
-    if (bps == null) return null;
-    if ((Date.now() - stageStart) / 1000 < REFINE_THRESHOLD_SEC) {
-      const refined = await timeStage(config.server, config.deviceId, config.apiKey, STAGE_SIZES[1]);
-      if (refined != null) bps = refined;
-    }
-    logger.info("Server bitrate measured", { service: "BitrateTest", mbps: Math.round(bps / 100_000) / 10, remembered: options?.remember !== false });
-    if (options?.remember !== false) await remember(config.server, bps);
-    return bps;
-  } catch (error) {
-    logger.debug("Bitrate test failed", { service: "BitrateTest", error: String(error) });
-    return null;
-  }
+export function nudgeBitrateMemory(): void {
+  // The launch warm-up is delayed off the first paint on purpose, and the first
+  // navigation lands well inside that delay.
+  if (!warmedOnce) return;
+  if (nudgeTimer != null) return;
+  if (Date.now() - lastNudgeAt < NUDGE_THROTTLE_MS) return;
+  nudgeTimer = setTimeout(() => {
+    nudgeTimer = null;
+    lastNudgeAt = Date.now();
+    void warmIfStale();
+  }, NUDGE_DEBOUNCE_MS);
 }

--- a/services/jellyfin/bitrateTest.ts
+++ b/services/jellyfin/bitrateTest.ts
@@ -7,11 +7,8 @@
  * a larger one only when the link looks fast enough for the small one to be
  * timer-noise.
  *
- * A reading belongs to a server AND to the network it was taken on, because
- * those are the two things that make it wrong. Same subnet: it stands however
- * old it is, since the routing gate in useVideoPlayback would rather have a
- * stale LAN number than none. Different subnet: it is void however fresh it is.
- * Age drives RE-MEASUREMENT, never discard.
+ * A reading is keyed to the server and to the subnet it was taken on: it stands at
+ * any age on that subnet, is void on another, and age only drives re-measurement.
  */
 
 import * as SecureStore from "expo-secure-store";
@@ -20,7 +17,7 @@ import { isPlaybackHeld } from "@/services/playbackHold";
 import { logger } from "@/utils/logger";
 import { API_TIMEOUTS, STORAGE_KEYS } from "./constants";
 import { fetchWithTimeout } from "./http";
-import { getAuthHeader, getConfig } from "./session";
+import { getAuthHeader, getConfig, type JellyfinConfig } from "./session";
 
 /** Probe sizes in bytes: quick first stage, refining second stage. */
 const STAGE_SIZES = [500_000, 2_000_000];
@@ -52,8 +49,8 @@ interface BitrateMemory {
 
 /** Hosts whose last probe failed. Session-only: a relaunch retries clean. */
 const failedAt = new Map<string, number>();
-/** The one memory probe in flight, shared by every caller. */
-let inFlight: Promise<number | null> | null = null;
+/** The memory probe in flight, shared by every caller asking about the same host. */
+let inFlight: { host: string; probe: Promise<number | null> } | null = null;
 let cachedNetworkId: { id: string | null; at: number } | null = null;
 let nudgeTimer: ReturnType<typeof setTimeout> | null = null;
 let lastNudgeAt = 0;
@@ -82,11 +79,7 @@ async function currentNetworkId(): Promise<string | null> {
   return id;
 }
 
-/**
- * Does this entry still answer for the link in front of us? Matching subnets say
- * yes at any age. A different subnet is a different link. Unknown on either side
- * leaves only the age backstop.
- */
+/** Matching subnet answers at any age; unknown on either side leaves the age backstop. */
 function entryAnswersFor(entry: BitrateEntry | undefined, networkId: string | null): entry is BitrateEntry {
   if (!entry) return false;
   if (networkId != null && entry.net != null) return entry.net === networkId;
@@ -118,10 +111,7 @@ export async function rememberedBitrate(): Promise<number | null> {
   return entryAnswersFor(active.entry, active.networkId) ? active.entry.bps : null;
 }
 
-/**
- * Settings surface: the reading with a freshness verdict. `fresh` uses the same
- * window as the triggers, so the screen re-measures exactly when they would.
- */
+/** Settings surface: the reading plus the triggers' own freshness verdict. */
 export async function rememberedBitrateStatus(): Promise<{ bps: number; fresh: boolean } | null> {
   const active = await activeEntry();
   if (!active || !entryAnswersFor(active.entry, active.networkId)) return null;
@@ -150,10 +140,7 @@ async function timeStage(server: string, deviceId: string, apiKey: string | unde
   return (body.byteLength * 8) / seconds;
 }
 
-async function runProbe(shouldRemember: boolean): Promise<number | null> {
-  const config = await getConfig();
-  if (!config.server || !config.apiKey) return null;
-  const host = serverHost(config.server);
+async function runProbe(config: JellyfinConfig, host: string, shouldRemember: boolean): Promise<number | null> {
   try {
     const stageStart = Date.now();
     let bps = await timeStage(config.server, config.deviceId, config.apiKey, STAGE_SIZES[0]);
@@ -171,13 +158,13 @@ async function runProbe(shouldRemember: boolean): Promise<number | null> {
         logger.warn("Bitrate refine stage failed, keeping the small-stage reading", error, { service: "BitrateTest" });
       }
     }
+    const net = shouldRemember ? await currentNetworkId() : null;
     failedAt.delete(host);
-    logger.info("Server bitrate measured", { service: "BitrateTest", mbps: Math.round(bps / 100_000) / 10, remembered: shouldRemember });
-    if (shouldRemember) await remember(config.server, bps, await currentNetworkId());
+    logger.info("Server bitrate measured", { service: "BitrateTest", mbps: Math.round(bps / 100_000) / 10, net, remembered: shouldRemember });
+    if (shouldRemember) await remember(config.server, bps, net);
     return bps;
   } catch (error) {
-    // Only the memory probe feeds the backoff: the in-playback one shares the
-    // link with the player's segments, so its failures say nothing about the host.
+    // Only the memory probe feeds the backoff: the in-playback one shares the link.
     if (shouldRemember) failedAt.set(host, Date.now());
     logger.warn("Bitrate test failed", error, { service: "BitrateTest", host });
     return null;
@@ -185,76 +172,71 @@ async function runProbe(shouldRemember: boolean): Promise<number | null> {
 }
 
 /**
- * Measure the link to the configured server, in bits/second.
- *
- * Concurrent callers share one download: a server switch arms both the warm-up
- * and the settings read, and two probes on one link only measure each other.
- *
- * `remember: false` is the in-playback probe and stays outside that sharing. It
- * runs while the player has the link, so its reading bounds the LEFTOVER
- * bandwidth: safe for a step-up decision, poison as routing memory.
- *
- * Null on any failure — callers fall back to their ceiling, which is exactly the
- * pre-adaptive behavior.
+ * Measure the link to the configured server, in bits/second. Concurrent callers
+ * share one download. `remember: false` is the in-playback probe: it measures
+ * LEFTOVER bandwidth, so it stays out of both the sharing and the memory.
  */
 export async function measureServerBitrate(options?: { remember?: boolean }): Promise<number | null> {
-  if (options?.remember === false) return runProbe(false);
-  if (!inFlight) {
-    inFlight = runProbe(true).finally(() => {
-      inFlight = null;
-    });
-  }
-  return inFlight;
-}
-
-/**
- * Measure unless something already answers for this link: a reading on this
- * network inside the refresh window, a failure still inside its backoff, or
- * playback holding the link.
- */
-async function warmIfStale(): Promise<void> {
-  if (isPlaybackHeld()) return;
-  // Every trigger re-reads the interface: a foreground or a switch is exactly
-  // when the device may have moved networks.
-  cachedNetworkId = null;
   const config = await getConfig();
-  if (!config.server || !config.apiKey) return;
+  if (!config.server || !config.apiKey) return null;
   const host = serverHost(config.server);
+  if (options?.remember === false) return runProbe(config, host, false);
+
   const failed = failedAt.get(host);
-  if (failed != null && Date.now() - failed < FAILURE_BACKOFF_MS) return;
-  const active = await activeEntry();
-  if (active && entryAnswersFor(active.entry, active.networkId) && Date.now() - active.entry.at < REFRESH_AGE_MS) return;
-  await measureServerBitrate();
+  if (failed != null && Date.now() - failed < FAILURE_BACKOFF_MS) return null;
+
+  let current = inFlight;
+  if (current?.host !== host) {
+    current = {
+      host,
+      probe: runProbe(config, host, true).finally(() => {
+        // A switch mid-probe already installed the next host; leave that one alone.
+        if (inFlight?.host === host) inFlight = null;
+      }),
+    };
+    inFlight = current;
+  }
+  return current.probe;
 }
 
 /**
- * Warm the memory in the background: launch, sign-in, account switch, a URL the
- * recovery ladder adopted, a foreground. The delay keeps the probe download off
- * app launch and the library's first paint.
+ * The idle-moment measurement every background trigger and Settings share: it
+ * declines to playback, to a reading still inside the refresh window, and (via
+ * measureServerBitrate) to a host still inside its failure backoff.
+ */
+export async function measureIfIdle(): Promise<number | null> {
+  if (isPlaybackHeld()) return null;
+  // Every trigger re-reads the interface: this is when the device may have moved.
+  cachedNetworkId = null;
+  const active = await activeEntry();
+  if (!active) return null;
+  if (entryAnswersFor(active.entry, active.networkId) && Date.now() - active.entry.at < REFRESH_AGE_MS) return null;
+  return measureServerBitrate();
+}
+
+/**
+ * Warm the memory in the background: launch, sign-in, account switch, adopted URL,
+ * foreground. The delay keeps the download off the library's first paint.
  */
 export function warmBitrateMemory(delayMs: number = 5_000): void {
   setTimeout(() => {
     warmedOnce = true;
-    void warmIfStale();
+    void measureIfIdle();
   }, delayMs);
 }
 
 /**
- * Navigation-rate entry point. A burst collapses into one attempt and attempts
- * are floored a minute apart, so browsing costs a keychain read rather than a
- * download. What it protects is the routing gate in useVideoPlayback: that gate
- * reads this memory and deliberately never probes for itself, so a session that
- * starts on cold memory silently loses it.
+ * Navigation-rate entry point, debounced and floored a minute apart, so browsing
+ * costs a keychain read rather than a download.
  */
 export function nudgeBitrateMemory(): void {
-  // The launch warm-up is delayed off the first paint on purpose, and the first
-  // navigation lands well inside that delay.
+  // Inert until the warm-up runs: the first navigation lands inside its delay.
   if (!warmedOnce) return;
   if (nudgeTimer != null) return;
   if (Date.now() - lastNudgeAt < NUDGE_THROTTLE_MS) return;
   nudgeTimer = setTimeout(() => {
     nudgeTimer = null;
     lastNudgeAt = Date.now();
-    void warmIfStale();
+    void measureIfIdle();
   }, NUDGE_DEBOUNCE_MS);
 }

--- a/services/jellyfin/connection.ts
+++ b/services/jellyfin/connection.ts
@@ -444,8 +444,7 @@ export async function adoptRecoveredServerUrl(url: string): Promise<void> {
   await clearContentCaches("after URL recovery");
   logger.info("Adopted recovered server URL", { service: "JellyfinAPI", url: cleanUrl });
   notifyAuthChange();
-  // A moved server is a new memory key with nothing in it, and the routing gate
-  // reads that memory without ever probing for itself.
+  // A moved server is a new memory key with nothing in it.
   warmBitrateMemory();
 }
 
@@ -495,7 +494,7 @@ export async function restoreLastConnection(): Promise<{ url: string; serverName
 
   logger.info("Restored last connection", { service: "JellyfinAPI", url: workingUrl, serverName });
   notifyAuthChange();
-  // A corrected protocol/port is a different memory key, same reason as above.
+  // A corrected protocol/port is a different memory key.
   warmBitrateMemory();
   return { url: workingUrl, serverName: serverName || workingUrl };
 }

--- a/services/jellyfin/connection.ts
+++ b/services/jellyfin/connection.ts
@@ -6,6 +6,7 @@
  */
 import { isLocalNetworkPrimed, LOCAL_NETWORK_GRACE_MS, LOCAL_NETWORK_POLL_MS, markLocalNetworkPrimedFor } from "@/services/localNetworkPermission";
 import { JellyfinPublicServerInfo, SavedServer } from "@/types/jellyfin";
+import { warmBitrateMemory } from "./bitrateTest";
 import { logger } from "@/utils/logger";
 import * as SecureStore from "expo-secure-store";
 import { Platform } from "react-native";
@@ -443,6 +444,9 @@ export async function adoptRecoveredServerUrl(url: string): Promise<void> {
   await clearContentCaches("after URL recovery");
   logger.info("Adopted recovered server URL", { service: "JellyfinAPI", url: cleanUrl });
   notifyAuthChange();
+  // A moved server is a new memory key with nothing in it, and the routing gate
+  // reads that memory without ever probing for itself.
+  warmBitrateMemory();
 }
 
 /**
@@ -491,5 +495,7 @@ export async function restoreLastConnection(): Promise<{ url: string; serverName
 
   logger.info("Restored last connection", { service: "JellyfinAPI", url: workingUrl, serverName });
   notifyAuthChange();
+  // A corrected protocol/port is a different memory key, same reason as above.
+  warmBitrateMemory();
   return { url: workingUrl, serverName: serverName || workingUrl };
 }

--- a/services/jellyfin/http.ts
+++ b/services/jellyfin/http.ts
@@ -19,10 +19,8 @@
  * The timer is cleared in a `finally`, so every exit path is covered by construction
  * rather than by remembering to write `clearTimeout` in each branch.
  *
- * The budget covers the response BODY, not just its head, because the app runs React
- * Native's fetch (EXPO_PUBLIC_USE_RN_FETCH in .env), which resolves in xhr.onload once
- * the whole body has arrived. Dropping that flag hands every call site expo/fetch, which
- * resolves at the head and would leave the download itself unbounded.
+ * The budget covers the response BODY: the app runs React Native's fetch
+ * (EXPO_PUBLIC_USE_RN_FETCH in .env), which resolves once the whole body has arrived.
  *
  * @param timeoutMessage Optional replacement for the raw AbortError when the timeout
  *   fires. Callers that had their own AbortError conversion pass their exact previous

--- a/services/jellyfin/http.ts
+++ b/services/jellyfin/http.ts
@@ -19,6 +19,11 @@
  * The timer is cleared in a `finally`, so every exit path is covered by construction
  * rather than by remembering to write `clearTimeout` in each branch.
  *
+ * The budget covers the response BODY, not just its head, because the app runs React
+ * Native's fetch (EXPO_PUBLIC_USE_RN_FETCH in .env), which resolves in xhr.onload once
+ * the whole body has arrived. Dropping that flag hands every call site expo/fetch, which
+ * resolves at the head and would leave the download itself unbounded.
+ *
  * @param timeoutMessage Optional replacement for the raw AbortError when the timeout
  *   fires. Callers that had their own AbortError conversion pass their exact previous
  *   string; callers that had none pass nothing and the AbortError propagates unchanged.

--- a/services/localNetworkIdentity.ts
+++ b/services/localNetworkIdentity.ts
@@ -1,14 +1,9 @@
 /**
  * localNetworkIdentity.ts
  *
- * What network this device is on: its own IPv4 configuration, and the subnet
- * label derived from it.
- *
- * A leaf, importing nothing from services/. That is the point of it being
- * separate from networkDiscovery, which pulls the jellyfinApi barrel to reach
- * checkServerInfo: anything under services/jellyfin/ that needs the device's
- * network would have to import it dynamically to break the cycle, and a dynamic
- * import is invisible to Jest's module registry.
+ * What network this device is on: its own IPv4 configuration and the subnet label
+ * derived from it. A leaf, importing nothing from services/, so services/jellyfin/
+ * can reach it without cycling through the jellyfinApi barrel.
  */
 
 import { NativeModules, Platform } from "react-native";

--- a/services/localNetworkIdentity.ts
+++ b/services/localNetworkIdentity.ts
@@ -1,0 +1,88 @@
+/**
+ * localNetworkIdentity.ts
+ *
+ * What network this device is on: its own IPv4 configuration, and the subnet
+ * label derived from it.
+ *
+ * A leaf, importing nothing from services/. That is the point of it being
+ * separate from networkDiscovery, which pulls the jellyfinApi barrel to reach
+ * checkServerInfo: anything under services/jellyfin/ that needs the device's
+ * network would have to import it dynamically to break the cycle, and a dynamic
+ * import is invisible to Jest's module registry.
+ */
+
+import { NativeModules, Platform } from "react-native";
+import { logger } from "@/utils/logger";
+
+const { NetworkInfo } = NativeModules;
+
+/** The device's own IPv4 configuration, from getifaddrs on the native side. */
+export interface LocalNetworkInfo {
+  ip: string;
+  netmask: string;
+  interfaceName: string;
+}
+
+/**
+ * Read this device's IPv4 address and netmask.
+ *
+ * Returns null when the native module is unavailable (Android, web, tests) or
+ * the device has no usable interface, so callers degrade to manual entry
+ * instead of throwing.
+ */
+export async function getLocalNetworkInfo(): Promise<LocalNetworkInfo | null> {
+  if (Platform.OS !== "ios" || !NetworkInfo?.getLocalNetworkInfo) {
+    return null;
+  }
+  try {
+    const info = await NetworkInfo.getLocalNetworkInfo();
+    if (!info?.ip || !info?.netmask) return null;
+    return info as LocalNetworkInfo;
+  } catch (error) {
+    logger.warn("Failed to read local network info", error, { service: "NetworkDiscovery" });
+    return null;
+  }
+}
+
+/** Parse dotted-quad IPv4 text into a number. Returns null for anything malformed. */
+export function parseIPv4(value: string): number | null {
+  const parts = value.trim().split(".");
+  if (parts.length !== 4) return null;
+
+  let result = 0;
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    result = result * 256 + octet;
+  }
+  return result;
+}
+
+/** Format a number back into dotted-quad IPv4 text. */
+export function formatIPv4(value: number): string {
+  return [(value >>> 24) & 255, (value >>> 16) & 255, (value >>> 8) & 255, value & 255].join(".");
+}
+
+/** Count the leading 1-bits of a netmask, e.g. 255.255.254.0 -> 23. */
+function maskToPrefix(mask: number): number {
+  let prefix = 0;
+  for (let bit = 31; bit >= 0 && (mask & (1 << bit)) !== 0; bit--) prefix++;
+  return prefix;
+}
+
+/**
+ * Human-readable label for a subnet. With a netmask this is exact CIDR
+ * ("10.48.0.0/23"); without one it falls back to the /24 the address sits in.
+ */
+export function describeSubnet(ip: string, netmask?: string): string {
+  const address = parseIPv4(ip);
+  const mask = netmask ? parseIPv4(netmask) : null;
+
+  if (address !== null && mask !== null) {
+    return `${formatIPv4((address & mask) >>> 0)}/${maskToPrefix(mask)}`;
+  }
+
+  const parts = ip.split(".");
+  return parts.length === 4 ? `${parts[0]}.${parts[1]}.${parts[2]}.x` : ip;
+}

--- a/services/localNetworkIdentity.ts
+++ b/services/localNetworkIdentity.ts
@@ -34,7 +34,7 @@ export async function getLocalNetworkInfo(): Promise<LocalNetworkInfo | null> {
     if (!info?.ip || !info?.netmask) return null;
     return info as LocalNetworkInfo;
   } catch (error) {
-    logger.warn("Failed to read local network info", error, { service: "NetworkDiscovery" });
+    logger.warn("Failed to read local network info", error, { service: "LocalNetworkIdentity" });
     return null;
   }
 }

--- a/services/networkDiscovery.ts
+++ b/services/networkDiscovery.ts
@@ -15,17 +15,15 @@
 
 import { checkServerInfo } from "@/services/jellyfinApi";
 import { isLocalNetworkPrimed, LOCAL_NETWORK_GRACE_MS, LOCAL_NETWORK_POLL_MS, markLocalNetworkPrimedFor } from "@/services/localNetworkPermission";
+import { describeSubnet, formatIPv4, getLocalNetworkInfo, parseIPv4, type LocalNetworkInfo } from "@/services/localNetworkIdentity";
 import { logger } from "@/utils/logger";
 import { NativeModules, Platform } from "react-native";
 
-const { NetworkInfo } = NativeModules;
+// Re-exported: the scan's own callers already import them from here.
+export { describeSubnet, getLocalNetworkInfo };
+export type { LocalNetworkInfo };
 
-/** The device's own IPv4 configuration, from getifaddrs on the native side. */
-export interface LocalNetworkInfo {
-  ip: string;
-  netmask: string;
-  interfaceName: string;
-}
+const { NetworkInfo } = NativeModules;
 
 /** A Jellyfin server found by sweeping the local subnet. */
 export interface DiscoveredServer {
@@ -122,47 +120,6 @@ interface OpenPort {
 }
 
 /**
- * Read this device's IPv4 address and netmask.
- *
- * Returns null when the native module is unavailable (Android, web, tests) or
- * the device has no usable interface, so callers degrade to manual entry
- * instead of throwing.
- */
-export async function getLocalNetworkInfo(): Promise<LocalNetworkInfo | null> {
-  if (Platform.OS !== "ios" || !NetworkInfo?.getLocalNetworkInfo) {
-    return null;
-  }
-  try {
-    const info = await NetworkInfo.getLocalNetworkInfo();
-    if (!info?.ip || !info?.netmask) return null;
-    return info as LocalNetworkInfo;
-  } catch (error) {
-    logger.warn("Failed to read local network info", error, { service: "NetworkDiscovery" });
-    return null;
-  }
-}
-
-/** Parse dotted-quad IPv4 text into a number. Returns null for anything malformed. */
-function parseIPv4(value: string): number | null {
-  const parts = value.trim().split(".");
-  if (parts.length !== 4) return null;
-
-  let result = 0;
-  for (const part of parts) {
-    if (!/^\d{1,3}$/.test(part)) return null;
-    const octet = Number(part);
-    if (octet > 255) return null;
-    result = result * 256 + octet;
-  }
-  return result;
-}
-
-/** Format a number back into dotted-quad IPv4 text. */
-function formatIPv4(value: number): string {
-  return [(value >>> 24) & 255, (value >>> 16) & 255, (value >>> 8) & 255, value & 255].join(".");
-}
-
-/**
  * List every host address to probe on the device's local subnet.
  *
  * The interface's real netmask is honoured up to MAX_SWEEP_HOSTS, so a /23 (a
@@ -255,29 +212,6 @@ export function subnetMismatchHint(input: string, local: LocalNetworkInfo | null
   if (sameSubnet) return null;
 
   return `This device is on ${describeSubnet(local.ip, local.netmask)}, but that address is outside it. Unless those networks are routed to each other, the server won't be reachable from here.`;
-}
-
-/** Count the leading 1-bits of a netmask, e.g. 255.255.254.0 -> 23. */
-function maskToPrefix(mask: number): number {
-  let prefix = 0;
-  for (let bit = 31; bit >= 0 && (mask & (1 << bit)) !== 0; bit--) prefix++;
-  return prefix;
-}
-
-/**
- * Human-readable label for a subnet. With a netmask this is exact CIDR
- * ("10.48.0.0/23"); without one it falls back to the /24 the address sits in.
- */
-export function describeSubnet(ip: string, netmask?: string): string {
-  const address = parseIPv4(ip);
-  const mask = netmask ? parseIPv4(netmask) : null;
-
-  if (address !== null && mask !== null) {
-    return `${formatIPv4((address & mask) >>> 0)}/${maskToPrefix(mask)}`;
-  }
-
-  const parts = ip.split(".");
-  return parts.length === 4 ? `${parts[0]}.${parts[1]}.${parts[2]}.x` : ip;
 }
 
 /**

--- a/services/playbackHold.ts
+++ b/services/playbackHold.ts
@@ -1,12 +1,7 @@
 /**
- * "Playback owns the link right now."
- *
- * Its own module, importing nothing: the video host, the audio manager and the
- * Jellyfin services all read or write this, and any of them importing another
- * would cycle through the jellyfinApi barrel.
- *
- * Owner-keyed rather than a bare boolean, so audio ending cannot clear the
- * video session's hold.
+ * "Playback owns the link right now." A leaf module: any of its callers importing
+ * another would cycle through the jellyfinApi barrel. Owner-keyed so audio ending
+ * cannot clear the video session's hold.
  */
 const owners = new Set<string>();
 

--- a/services/playbackHold.ts
+++ b/services/playbackHold.ts
@@ -1,0 +1,25 @@
+/**
+ * "Playback owns the link right now."
+ *
+ * Its own module, importing nothing: the video host, the audio manager and the
+ * Jellyfin services all read or write this, and any of them importing another
+ * would cycle through the jellyfinApi barrel.
+ *
+ * Owner-keyed rather than a bare boolean, so audio ending cannot clear the
+ * video session's hold.
+ */
+const owners = new Set<string>();
+
+/** Held by whichever surface owns live playback ("video", "audio"), cleared when it ends. */
+export function setPlaybackHold(owner: string, active: boolean): void {
+  if (active) {
+    owners.add(owner);
+  } else {
+    owners.delete(owner);
+  }
+}
+
+/** True while playback owns the link: background work that downloads stands down. */
+export function isPlaybackHeld(): boolean {
+  return owners.size > 0;
+}


### PR DESCRIPTION
The Settings link meter did not update after a server switch, and a relaunch did not fix it. The same stored measurement feeds the direct-play gate at `useVideoPlayback.ts:655`, which reads it and never measures for itself, so whenever it was empty that gate was off with no sign of it.

### Which stored measurement gets used

Each entry now records the subnet it was measured on.

- Same subnet: used, however old it is.
- Different subnet: not used, however recent it is.
- Subnet unknown, or an entry saved before this change: the old 24h expiry.

That replaces the flat 24h expiry, which threw away a valid LAN reading after a day and kept a wrong one after a network change.

### bitrateTest.ts

- Concurrent measurements share one download. `remember: false` (the in-playback probe) stays outside that.
- The 2MB refine runs in its own try. A throw there keeps the 500KB reading instead of discarding it.
- A host whose measurement fails backs off 60s. Only the memory probe feeds that.
- Failures log at `warn`. `logger.ts:92` silences `debug` and `info` outside dev, so they were invisible in release builds.

### Triggers added

| trigger | site |
|---|---|
| foreground | `_layout.tsx`, `useAppStateRefresh` |
| recovered or corrected server URL | `connection.ts:444`, `:495` |
| Settings focus, was mount only | `settings.tsx` `useFocusEffect` |
| navigation | `_layout.tsx`, navigationRef `state` listener |

Navigation: 2s debounce collapses a burst, 60s floor between attempts, skips `player`/`audio-player`/`video-info`, and does nothing until the launch warm-up has run.

Launch, sign-in, account switch and demo connect were already wired and are unchanged.

### playbackHold

`services/playbackHold.ts`, owner-keyed. Set by player-host (`video`) and audioPlayerManager (`audio`, at `startQueue` and `teardownLocalState`). Read by `useAppStateRefresh` and `warmIfStale`. Replaces `foregroundRefreshHeld`, which only knew about video and had no unmount cleanup, so measuring could run over audio playback.

### localNetworkIdentity

`getLocalNetworkInfo`, `describeSubnet`, `parseIPv4`, `formatIPv4`, `maskToPrefix` moved out of `networkDiscovery.ts`, which re-exports the public two. `connectionRecovery.ts`, `useNetworkScan.ts`, `NotConnectedSection.tsx` and the existing tests are unchanged.

Needed because networkDiscovery imports the jellyfinApi barrel, so reaching it from `services/jellyfin/` meant `await import()`, which throws under Jest: `A dynamic import callback was invoked without --experimental-vm-modules`.

### Tests

`services/__tests__/bitrateTest.test.ts`, 19 cases: timing and storage, refine gate, refine salvage, probe sharing, in-playback isolation, the subnet rules above, freshness verdict, and each trigger gate.

Full suite 64/64, 1186 tests. tsc and ESLint clean.

Not run on device. The subnet read returns null in Jest and on the simulator.
